### PR TITLE
Fix Enter key closing threat modal instead of saving

### DIFF
--- a/.changeset/fix-enter-modal.md
+++ b/.changeset/fix-enter-modal.md
@@ -1,0 +1,5 @@
+---
+"@eop/client": patch
+---
+
+Prevent Enter key from closing threat modal by preventing default form submission behavior.

--- a/apps/client/src/components/threatmodal/threatmodal.tsx
+++ b/apps/client/src/components/threatmodal/threatmodal.tsx
@@ -199,7 +199,7 @@ const ThreatModal: FC<ThreatModalProps> = ({
 
   return (
     <Modal isOpen={isOpen}>
-      <Form>
+      <Form onSubmit={(e) => e.preventDefault()}>
         <ModalHeader
           toggle={isOwner ? () => moves.toggleModal?.() : undefined}
           style={{ width: '100%' }}


### PR DESCRIPTION
## Summary
Fixes issue #230 - Enter key was closing the threat modal instead of saving changes.

## Root Cause
The `<Form>` component wrapping the modal content had no `onSubmit` handler, so pressing Enter triggered default form submission behavior which caused the modal to close without saving.

## Fix
Added `onSubmit={(e) => e.preventDefault()}` to prevent default form submission, allowing the modal to remain open for manual save or cancel action.

## Testing
- All tests pass
- Linting passes
- Manual reproduction confirmed the issue is resolved