### PR TITLE
Fix Update and Remove threat buttons remaining enabled after passing

### DIFF
--- a/.changeset/petite-crews-rest.md
+++ b/.changeset/petite-crews-rest.md
@@ -1,0 +1,5 @@
+---
+"@eop/client": patch
+---
+
+Fix Update and Remove threat buttons remaining clickable after a player has passed. They are now disabled in the same conditions as the Add Threat button.

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ deploy/
 # Agents
 .agents
 .opencode
+
+# Playwright
+.playwright
+.playwright-cli

--- a/apps/client/src/components/threatbar/threatbar.tsx
+++ b/apps/client/src/components/threatbar/threatbar.tsx
@@ -154,6 +154,11 @@ const Threatbar: FC<ThreatbarProps> = ({
                     <Col xs="6">
                       <Button
                         block
+                        disabled={
+                          !isInThreatStage ||
+                          (playerID !== null &&
+                            G.passed.includes(playerID))
+                        }
                         onClick={() => moves.toggleModalUpdate?.(val)}
                       >
                         <FontAwesomeIcon icon={faEdit} /> Update
@@ -163,6 +168,11 @@ const Threatbar: FC<ThreatbarProps> = ({
                       <Button
                         block
                         color="danger"
+                        disabled={
+                          !isInThreatStage ||
+                          (playerID !== null &&
+                            G.passed.includes(playerID))
+                        }
                         onClick={() => setThreatToBeDeleted(val)}
                       >
                         <FontAwesomeIcon icon={faTrash} /> Remove


### PR DESCRIPTION
## Summary

Fixes #320

- The **Update** and **Remove** buttons on a threat card were still clickable after a player passed, even though the underlying moves (`toggleModalUpdate`, `deleteThreat`) correctly rejected them with `INVALID_MOVE`
- This created a confusing UX where the UI appeared to accept the action but nothing happened
- Both buttons now receive a `disabled` prop using the same condition already applied to the **Add Threat** button: disabled when the player has passed (`G.passed.includes(playerID)`) or the game is not in the threat stage (`!isInThreatStage`)

## Changes

- `apps/client/src/components/threatbar/threatbar.tsx`: Added `disabled` prop to the Update and Remove buttons