### PR TITLE
Migrate to ThreatDragon v2 scheme and fix several CVEs

### DIFF
--- a/apps/client/src/components/board/board.tsx
+++ b/apps/client/src/components/board/board.tsx
@@ -1,4 +1,9 @@
-import {getDealtCard, ModelType, SPECTATOR, ThreatDragonModelV2} from '@eop/shared';
+import {
+  getDealtCard,
+  ModelType,
+  SPECTATOR,
+  ThreatDragonModelV2,
+} from '@eop/shared';
 import type { BoardProps as BoardgameIOBoardProps } from 'boardgame.io/react';
 import { FC, useCallback, useEffect, useState } from 'react';
 
@@ -19,28 +24,28 @@ import './board.css';
 
 import type { GameState } from '@eop/shared';
 
-type PlayersResponse = { players: Array<{ id: number; name: string }> };
-
 type BoardProps = Pick<
   BoardgameIOBoardProps<GameState>,
   'G' | 'ctx' | 'matchID' | 'moves' | 'playerID' | 'credentials'
 >;
 
 const Board: FC<BoardProps> = ({
-                                 G,
-                                 ctx,
-                                 matchID,
-                                 moves,
-                                 playerID,
-                                 credentials,
-                               }) => {
+  G,
+  ctx,
+  matchID,
+  moves,
+  playerID,
+  credentials,
+}) => {
   const initialNames = Array.from<string>({
     length: ctx.numPlayers,
   }).fill('No Name');
 
   const [names, setNames] = useState(initialNames);
 
-  const [model, setModel] = useState<ThreatDragonModelV2 | undefined>(undefined);
+  const [model, setModel] = useState<ThreatDragonModelV2 | undefined>(
+    undefined,
+  );
   const apiBase = '/api';
 
   const updateName = useCallback((index: number, name: string) => {

--- a/apps/client/src/components/board/board.tsx
+++ b/apps/client/src/components/board/board.tsx
@@ -78,8 +78,10 @@ const Board: FC<BoardProps> = ({
 
   const updateNames = useCallback(async () => {
     // TODO: Type with valibot and consider using react-query.
-    const body = await apiGetRequest<PlayersResponse>('players');
-    for (const player of body?.players ?? []) {
+    const body = await apiGetRequest('players');
+    for (const player of (
+      body as { players: { id: number; name: string }[] } | undefined
+    )?.players ?? []) {
       if (typeof player.name !== 'undefined') {
         updateName(player.id, player.name);
       }
@@ -88,8 +90,11 @@ const Board: FC<BoardProps> = ({
 
   const updateModel = useCallback(async () => {
     // TODO: Type with valibot and consider using react-query.
-    const body = await apiGetRequest<ThreatDragonModelV2>('model');
-    setModel(body);
+    const body = await apiGetRequest('model');
+
+    const model = body as ThreatDragonModelV2 | undefined;
+
+    setModel(model);
   }, [apiGetRequest]);
 
   // consider using react-query instead

--- a/apps/client/src/components/model/model.tsx
+++ b/apps/client/src/components/model/model.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import * as joint from 'jointjs';
-import { FC, useCallback, useEffect, useState } from 'react';
-import { Nav, NavItem, NavLink } from 'reactstrap';
+import React, {FC, useCallback, useEffect, useState} from 'react';
+import {Nav, NavItem, NavLink} from 'reactstrap';
 
 import 'jointjs/dist/joint.css';
 
@@ -10,12 +10,12 @@ import '../../jointjs/shapes';
 
 import './model.css';
 
-import type { ThreatDragonModel } from '@eop/shared';
+import type {CellV2, DiagramV2, ThreatDragonModelV2} from '@eop/shared';
 
 const SCROLL_SPEED = 1000;
 
 type ModelProps = {
-  model: ThreatDragonModel;
+  model: ThreatDragonModelV2;
   selectedDiagram: number;
   selectedComponent: string;
   onSelectDiagram?: (id: number) => void;
@@ -23,12 +23,12 @@ type ModelProps = {
 };
 
 const Model: FC<ModelProps> = ({
-  model,
-  selectedDiagram,
-  selectedComponent,
-  onSelectDiagram,
-  onSelectComponent,
-}) => {
+                                 model,
+                                 selectedDiagram,
+                                 selectedComponent,
+                                 onSelectDiagram,
+                                 onSelectComponent,
+                               }) => {
   const [graph] = useState(
     new joint.dia.Graph({}, { cellNamespace: joint.shapes }),
   );
@@ -62,17 +62,26 @@ const Model: FC<ModelProps> = ({
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
 
   useEffect(() => {
-    graph.fromJSON(model.detail.diagrams[selectedDiagram]?.diagramJson);
-    //paper.fitToContent(1, 1, 10, { allowNewOrigin: "any" });
+    const diagram = model.detail.diagrams[selectedDiagram];
+    if (!diagram) {
+      graph.clear();
+      return;
+    }
+    const jointJson = toJointGraphJson(diagram);
+    graph.fromJSON(jointJson);
+
+    // paper.fitToContent(1, 1, 10, { allowNewOrigin: 'any' });
   }, [graph, model, selectedDiagram]);
 
   useEffect(() => {
     // unhighlight all
     paper.model.getElements().forEach((e) => {
-      paper.findViewByModel(e).unhighlight();
+      const v = paper.findViewByModel(e);
+      v?.unhighlight();
     });
     paper.model.getLinks().forEach((e) => {
-      paper.findViewByModel(e).unhighlight();
+      const v = paper.findViewByModel(e);
+      v?.unhighlight();
     });
 
     // highlight the selected component
@@ -82,6 +91,9 @@ const Model: FC<ModelProps> = ({
     }
   }, [paper, selectedComponent]);
 
+  /**
+   * Selection + panning interaction
+   */
   useEffect(() => {
     const onCellPointerClick = (cellView: joint.dia.CellView) => {
       if (cellView.model.attributes.type !== 'tm.Boundary') {
@@ -98,11 +110,7 @@ const Model: FC<ModelProps> = ({
       setDragPosition({ x: x * scale.sx, y: y * scale.sy });
     };
 
-    const onBlankPointerDown = (
-      event: joint.dia.Event,
-      x: number,
-      y: number,
-    ) => {
+    const onBlankPointerDown = (event: joint.dia.Event, x: number, y: number) => {
       setDragging(true);
       setDragPositionScaled(x, y);
     };
@@ -112,12 +120,7 @@ const Model: FC<ModelProps> = ({
       setDragPositionScaled(x, y);
     };
 
-    const onCellPointerUp = (
-      cellView: joint.dia.CellView,
-      event: joint.dia.Event,
-      x: number,
-      y: number,
-    ) => {
+    const onCellPointerUp = (cellView: joint.dia.CellView, event: joint.dia.Event, x: number, y: number) => {
       stopDragging(x, y);
     };
 
@@ -145,6 +148,7 @@ const Model: FC<ModelProps> = ({
       const delta = -e.deltaY / SCROLL_SPEED;
       const newScale = joint.V(paper.layers).scale().sx + delta;
       paper.translate(0, 0);
+
       const p = offsetToLocalPoint(e.offsetX, e.offsetY, paper);
       paper.scale(newScale, newScale, p.x, p.y);
     },
@@ -182,6 +186,7 @@ const Model: FC<ModelProps> = ({
           ))}
         </Nav>
       </div>
+
       <div
         className="placeholder"
         ref={placeholderRef}
@@ -199,12 +204,262 @@ const offsetToLocalPoint = (
   offsetY: number,
   paper: joint.dia.Paper,
 ) => {
-  // Finds mouse position in unscaled version
   const svgPoint = paper.svg.createSVGPoint();
   svgPoint.x = offsetX;
   svgPoint.y = offsetY;
-  const offsetTransformed = svgPoint.matrixTransform(
+  return svgPoint.matrixTransform(
     paper.layers.getCTM()?.inverse(),
   );
-  return offsetTransformed;
 };
+
+/* =============================================================================
+   Helper: Threat Dragon V2 -> JointJS Graph JSON
+   ============================================================================= */
+
+/**
+ * Threat Dragon V2 uses diagram.cells[] with shape/zIndex/data.type and
+ * edge endpoints source.cell/target.cell. We map that into JointJS-compatible
+ * JSON cells (type/z/source.id/target.id etc.). [1](https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V2.json)[2](https://deepwiki.com/OWASP/threat-dragon/2.1-threat-model-data-structure)
+ */
+
+type JointAttrs = Record<string, unknown>;
+
+type JointEdgeEnd =
+  | { id: string; port?: string }
+  | { x: number; y: number }
+  | Record<string, never>;
+
+type JointLabel = {
+  position: number;
+  attrs: {
+    text: { text: string };
+  };
+};
+
+type JointCellBase = {
+  id: string;
+  type: string;
+  z: number;
+  attrs: JointAttrs;
+
+  description?: string;
+  hasOpenThreats?: boolean;
+  outOfScope?: boolean;
+  reasonOutOfScope?: string;
+  isTrustBoundary?: boolean;
+  threats?: unknown[];
+  visible?: boolean;
+};
+
+type JointNodeCell = JointCellBase & {
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+};
+
+type JointEdgeCell = JointCellBase & {
+  source: JointEdgeEnd;
+  target: JointEdgeEnd;
+  vertices: Array<{ x: number; y: number }>;
+  smooth?: boolean;
+  labels?: JointLabel[];
+
+  isBidirectional?: boolean;
+  isEncrypted?: boolean;
+  isPublicNetwork?: boolean;
+  protocol?: string;
+};
+
+type JointCell = JointNodeCell | JointEdgeCell;
+
+function toJointGraphJson(diagram: DiagramV2): { cells: JointCell[] } {
+  const cells = (diagram.cells ?? [])
+    .map(v2CellToJointCell)
+    .filter((c): c is JointCell => c !== null);
+
+  return { cells };
+}
+
+function v2CellToJointCell(cell: CellV2): JointCell | null {
+  const dataType = cell.data?.type; // e.g. "tm.Process"
+  const shape = cell.shape;
+
+  // Base mapping
+  const base: JointCellBase = {
+    id: cell.id,
+    type: mapToJointType(shape, dataType),
+    z: cell.zIndex ? cell.zIndex : 0,
+    attrs: normalizeAttrs(cell),
+  };
+
+  // Node cells: position + size
+  if (cell.position && cell.size) {
+    return {
+      ...base,
+      position: {x: cell.position.x, y: cell.position.y},
+      size: {width: cell.size.width, height: cell.size.height},
+
+      description: cell.data?.description ?? '',
+      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      outOfScope: !!cell.data?.outOfScope,
+      reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
+      isTrustBoundary: !!cell.data?.isTrustBoundary,
+      threats: cell.data?.threats ?? [],
+      visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
+    };
+  }
+
+  // Edge cells: source/target/vertices (flows, boundary curves)
+  if (cell.source || cell.target) {
+    const edge: JointEdgeCell = {
+      ...base,
+      source: mapEdgeEnd(cell.source),
+      target: mapEdgeEnd(cell.target),
+      vertices: Array.isArray(cell.vertices)
+        ? cell.vertices.map((v) => ({ x: v.x, y: v.y }))
+        : [],
+
+      smooth: typeof cell.connector === 'string' ? cell.connector === 'smooth' : undefined,
+
+      description: cell.data?.description ?? '',
+      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      outOfScope: !!cell.data?.outOfScope,
+      reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
+      isTrustBoundary: !!cell.data?.isTrustBoundary,
+      threats: cell.data?.threats ?? [],
+      visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
+    };
+
+    // Copy edge labels best-effort
+    const labels = mapEdgeLabels(cell);
+    if (labels.length) edge.labels = labels;
+
+    // If flow flags exist in data, put them at root too (optional, but helps if your UI reads them)
+    if (cell.data?.type === 'tm.Flow') {
+      const d = cell.data;
+      edge.isBidirectional = !!d.isBidirectional;
+      edge.isEncrypted = !!d.isEncrypted;
+      edge.isPublicNetwork = !!d.isPublicNetwork;
+      edge.protocol = typeof d.protocol === 'string' ? d.protocol : '';
+    }
+
+    return edge;
+  }
+
+  return null;
+}
+
+function mapToJointType(shape: string, dataType?: string): string {
+  // Prefer the semantic Threat Dragon type if present
+  if (typeof dataType === 'string' && dataType.startsWith('tm.')) {
+    // V2 extra: tm.BoundaryBox -> map to tm.Boundary so existing selection logic works
+    if (dataType === 'tm.BoundaryBox') return 'tm.Boundary';
+
+    // V2 extra: tm.Text blocks. If you don't have a tm.Text shape,
+    // we map it to tm.Process so it still renders (as a basic element).
+    if (dataType === 'tm.Text') return 'tm.Process';
+
+    return dataType;
+  }
+
+  // Fallback based on shape
+  switch (shape) {
+    case 'process':
+      return 'tm.Process';
+    case 'actor':
+      return 'tm.Actor';
+    case 'store':
+      return 'tm.Store';
+    case 'flow':
+      return 'tm.Flow';
+    case 'trust-boundary-curve':
+    case 'trust-boundary-box':
+      return 'tm.Boundary';
+    default:
+      return 'tm.Process';
+  }
+}
+
+function mapEdgeEnd(end: CellV2['source']): JointEdgeEnd {
+  if (!end) return {};
+
+  // boundary curves may use x/y endpoints
+  if (typeof end.x === 'number' && typeof end.y === 'number') {
+    return { x: end.x, y: end.y };
+  }
+
+  // flows use cell/port in V2; map to JointJS id/port
+  if (typeof end.cell === 'string') {
+    return { id: end.cell, port: typeof end.port === 'string' ? end.port : undefined };
+  }
+
+  return {};
+}
+
+/**
+ * Normalize V2 attrs to something that your existing JointJS shapes can render.
+ * We keep original attrs, but ensure attrs.text.text contains the element label.
+ */
+function normalizeAttrs(cell: CellV2): JointAttrs {
+  const attrs: JointAttrs = { ...(cell.attrs ?? {}) };
+
+  const name = getV2CellName(cell);
+  if (name) {
+    const textObj = (attrs as { text?: Record<string, unknown> }).text ?? {};
+    (attrs as { text?: Record<string, unknown> }).text = textObj;
+
+    if (typeof (textObj as { text?: unknown }).text !== 'string') {
+      (textObj as { text?: unknown }).text = name;
+    }
+  }
+
+  return attrs;
+}
+
+function getV2CellName(cell: CellV2): string {
+  // Prefer business name
+  if (typeof cell.data?.name === 'string' && cell.data.name.trim()) {
+    return cell.data.name;
+  }
+
+  // Common V2 patterns
+  const a = cell.attrs;
+  if (a && typeof a === 'object') {
+    const t1 = (a as { text?: { text?: unknown } }).text?.text;
+    if (typeof t1 === 'string' && t1.trim()) return t1;
+
+    const t2 = (a as { label?: { text?: unknown } }).label?.text;
+    if (typeof t2 === 'string' && t2.trim()) return t2;
+  }
+
+  return '';
+}
+
+function mapEdgeLabels(cell: CellV2): JointLabel[] {
+  const labels = cell.labels ?? [];
+  const out: JointLabel[] = [];
+
+  for (const l of labels) {
+    const attrs = l.attrs;
+    if (!attrs || typeof attrs !== 'object') continue;
+
+    // Prefer labelText.text; fallback to label.text
+    const labelText = (attrs as { labelText?: { text?: unknown } }).labelText?.text;
+    const fallback = (attrs as { label?: { text?: unknown } }).label?.text;
+
+    const text =
+      (typeof labelText === 'string' && labelText.trim())
+        ? labelText
+        : (typeof fallback === 'string' ? fallback : '');
+
+    if (!text || !text.trim()) continue;
+
+    out.push({
+      position: typeof l.position?.distance === 'number' ? l.position.distance : 0.5,
+      attrs: {
+        text: { text },
+      },
+    });
+  }
+
+  return out;
+}

--- a/apps/client/src/components/model/model.tsx
+++ b/apps/client/src/components/model/model.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import * as joint from 'jointjs';
-import React, {FC, useCallback, useEffect, useState} from 'react';
-import {Nav, NavItem, NavLink} from 'reactstrap';
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import { Nav, NavItem, NavLink } from 'reactstrap';
 
 import 'jointjs/dist/joint.css';
 
@@ -10,7 +10,7 @@ import '../../jointjs/shapes';
 
 import './model.css';
 
-import type {CellV2, DiagramV2, ThreatDragonModelV2} from '@eop/shared';
+import type { CellV2, DiagramV2, ThreatDragonModelV2 } from '@eop/shared';
 
 const SCROLL_SPEED = 1000;
 
@@ -23,12 +23,12 @@ type ModelProps = {
 };
 
 const Model: FC<ModelProps> = ({
-                                 model,
-                                 selectedDiagram,
-                                 selectedComponent,
-                                 onSelectDiagram,
-                                 onSelectComponent,
-                               }) => {
+  model,
+  selectedDiagram,
+  selectedComponent,
+  onSelectDiagram,
+  onSelectComponent,
+}) => {
   const [graph] = useState(
     new joint.dia.Graph({}, { cellNamespace: joint.shapes }),
   );
@@ -110,7 +110,11 @@ const Model: FC<ModelProps> = ({
       setDragPosition({ x: x * scale.sx, y: y * scale.sy });
     };
 
-    const onBlankPointerDown = (event: joint.dia.Event, x: number, y: number) => {
+    const onBlankPointerDown = (
+      event: joint.dia.Event,
+      x: number,
+      y: number,
+    ) => {
       setDragging(true);
       setDragPositionScaled(x, y);
     };
@@ -120,7 +124,12 @@ const Model: FC<ModelProps> = ({
       setDragPositionScaled(x, y);
     };
 
-    const onCellPointerUp = (cellView: joint.dia.CellView, event: joint.dia.Event, x: number, y: number) => {
+    const onCellPointerUp = (
+      cellView: joint.dia.CellView,
+      event: joint.dia.Event,
+      x: number,
+      y: number,
+    ) => {
       stopDragging(x, y);
     };
 
@@ -207,9 +216,7 @@ const offsetToLocalPoint = (
   const svgPoint = paper.svg.createSVGPoint();
   svgPoint.x = offsetX;
   svgPoint.y = offsetY;
-  return svgPoint.matrixTransform(
-    paper.layers.getCTM()?.inverse(),
-  );
+  return svgPoint.matrixTransform(paper.layers.getCTM()?.inverse());
 };
 
 /* =============================================================================
@@ -295,8 +302,8 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
   if (cell.position && cell.size) {
     return {
       ...base,
-      position: {x: cell.position.x, y: cell.position.y},
-      size: {width: cell.size.width, height: cell.size.height},
+      position: { x: cell.position.x, y: cell.position.y },
+      size: { width: cell.size.width, height: cell.size.height },
 
       description: cell.data?.description ?? '',
       hasOpenThreats: !!cell.data?.hasOpenThreats,
@@ -318,7 +325,10 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
         ? cell.vertices.map((v) => ({ x: v.x, y: v.y }))
         : [],
 
-      smooth: typeof cell.connector === 'string' ? cell.connector === 'smooth' : undefined,
+      smooth:
+        typeof cell.connector === 'string'
+          ? cell.connector === 'smooth'
+          : undefined,
 
       description: cell.data?.description ?? '',
       hasOpenThreats: !!cell.data?.hasOpenThreats,
@@ -389,7 +399,10 @@ function mapEdgeEnd(end: CellV2['source']): JointEdgeEnd {
 
   // flows use cell/port in V2; map to JointJS id/port
   if (typeof end.cell === 'string') {
-    return { id: end.cell, port: typeof end.port === 'string' ? end.port : undefined };
+    return {
+      id: end.cell,
+      port: typeof end.port === 'string' ? end.port : undefined,
+    };
   }
 
   return {};
@@ -443,18 +456,22 @@ function mapEdgeLabels(cell: CellV2): JointLabel[] {
     if (!attrs || typeof attrs !== 'object') continue;
 
     // Prefer labelText.text; fallback to label.text
-    const labelText = (attrs as { labelText?: { text?: unknown } }).labelText?.text;
+    const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
+      ?.text;
     const fallback = (attrs as { label?: { text?: unknown } }).label?.text;
 
     const text =
-      (typeof labelText === 'string' && labelText.trim())
+      typeof labelText === 'string' && labelText.trim()
         ? labelText
-        : (typeof fallback === 'string' ? fallback : '');
+        : typeof fallback === 'string'
+          ? fallback
+          : '';
 
     if (!text || !text.trim()) continue;
 
     out.push({
-      position: typeof l.position?.distance === 'number' ? l.position.distance : 0.5,
+      position:
+        typeof l.position?.distance === 'number' ? l.position.distance : 0.5,
       attrs: {
         text: { text },
       },

--- a/apps/client/src/components/model/model.tsx
+++ b/apps/client/src/components/model/model.tsx
@@ -96,7 +96,11 @@ const Model: FC<ModelProps> = ({
    */
   useEffect(() => {
     const onCellPointerClick = (cellView: joint.dia.CellView) => {
-      if (cellView.model.attributes.type !== 'tm.Boundary') {
+      if (
+        cellView.model.attributes.type !== 'tm.Boundary' &&
+        cellView.model.attributes.type !== 'tm.BoundaryBox' &&
+        cellView.model.attributes.type !== 'tm.Text'
+      ) {
         onSelectComponent?.(cellView.model.id.toString());
       }
     };
@@ -295,7 +299,7 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
     id: cell.id,
     type: mapToJointType(shape, dataType),
     z: cell.zIndex ? cell.zIndex : 0,
-    attrs: normalizeAttrs(cell),
+    attrs: normalizeAttrs(addCssClasses(cell)),
   };
 
   // Node cells: position + size
@@ -306,10 +310,7 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
       size: { width: cell.size.width, height: cell.size.height },
 
       description: cell.data?.description ?? '',
-      hasOpenThreats: !!cell.data?.hasOpenThreats,
-      outOfScope: !!cell.data?.outOfScope,
       reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
-      isTrustBoundary: !!cell.data?.isTrustBoundary,
       threats: cell.data?.threats ?? [],
       visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
     };
@@ -331,7 +332,7 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
           : undefined,
 
       description: cell.data?.description ?? '',
-      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      hasOpenThreats: cell.data?.hasOpenThreats,
       outOfScope: !!cell.data?.outOfScope,
       reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
       isTrustBoundary: !!cell.data?.isTrustBoundary,
@@ -360,16 +361,8 @@ function v2CellToJointCell(cell: CellV2): JointCell | null {
 
 function mapToJointType(shape: string, dataType?: string): string {
   // Prefer the semantic Threat Dragon type if present
-  if (typeof dataType === 'string' && dataType.startsWith('tm.')) {
-    // V2 extra: tm.BoundaryBox -> map to tm.Boundary so existing selection logic works
-    if (dataType === 'tm.BoundaryBox') return 'tm.Boundary';
-
-    // V2 extra: tm.Text blocks. If you don't have a tm.Text shape,
-    // we map it to tm.Process so it still renders (as a basic element).
-    if (dataType === 'tm.Text') return 'tm.Process';
-
+  if (typeof dataType === 'string' && dataType.startsWith('tm.'))
     return dataType;
-  }
 
   // Fallback based on shape
   switch (shape) {
@@ -382,8 +375,11 @@ function mapToJointType(shape: string, dataType?: string): string {
     case 'flow':
       return 'tm.Flow';
     case 'trust-boundary-curve':
-    case 'trust-boundary-box':
       return 'tm.Boundary';
+    case 'trust-boundary-box':
+      return 'tm.BoundaryBox';
+    case 'td-text-block':
+      return 'tm.Text';
     default:
       return 'tm.Process';
   }
@@ -428,6 +424,35 @@ function normalizeAttrs(cell: CellV2): JointAttrs {
   return attrs;
 }
 
+function addCssClasses(cell: CellV2) {
+  const threats = cell.data?.hasOpenThreats
+    ? 'hasOpenThreats'
+    : 'hasNoOpenThreats';
+  const scope = cell.data?.outOfScope ? 'isOutOfScope' : 'isInScope';
+  const direction = cell.data?.isBidirectional
+    ? 'isBidirectional'
+    : 'isUnidirectional';
+
+  if (!cell.attrs) cell.attrs = {};
+  cell.attrs['.element-shape'] = {
+    class: ['element-shape', scope, threats].join(' '),
+  };
+  cell.attrs['.element-text'] = {
+    class: ['element-text', threats].join(' '),
+  };
+  cell.attrs['.marker-target'] = {
+    class: ['marker-target', threats].join(' '),
+  };
+  cell.attrs['.marker-source'] = {
+    class: ['marker-source', threats, direction].join(' '),
+  };
+  cell.attrs['.connection'] = {
+    class: ['connection', scope, threats].join(' '),
+  };
+
+  return cell;
+}
+
 function getV2CellName(cell: CellV2): string {
   // Prefer business name
   if (typeof cell.data?.name === 'string' && cell.data.name.trim()) {
@@ -448,30 +473,19 @@ function getV2CellName(cell: CellV2): string {
 }
 
 function mapEdgeLabels(cell: CellV2): JointLabel[] {
-  const labels = cell.labels ?? [];
+  // the schema v2 as descripted here: https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/threat-dragon-v2.schema.json
+  // does not represent the actual model as saved with current Threat Dragon 2.6.2
+  let labels = cell.labels ?? []; // TD currently does not allow more then one label
+  // fallback
+  if (!labels) labels = [cell.data.name];
+
   const out: JointLabel[] = [];
 
-  for (const l of labels) {
-    const attrs = l.attrs;
-    if (!attrs || typeof attrs !== 'object') continue;
-
-    // Prefer labelText.text; fallback to label.text
-    const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
-      ?.text;
-    const fallback = (attrs as { label?: { text?: unknown } }).label?.text;
-
-    const text =
-      typeof labelText === 'string' && labelText.trim()
-        ? labelText
-        : typeof fallback === 'string'
-          ? fallback
-          : '';
-
+  for (const text of labels) {
     if (!text || !text.trim()) continue;
 
     out.push({
-      position:
-        typeof l.position?.distance === 'number' ? l.position.distance : 0.5,
+      position: 0.5,
       attrs: {
         text: { text },
       },

--- a/apps/client/src/components/threatbar/threatbar.test.tsx
+++ b/apps/client/src/components/threatbar/threatbar.test.tsx
@@ -1,10 +1,10 @@
-import { GameMode, ModelType } from '@eop/shared';
+import {GameMode, ModelType, ThreatDragonModelV2} from '@eop/shared';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
 import Threatbar from './threatbar';
 
-import type { GameState, ThreatDragonModel } from '@eop/shared';
+import type { GameState } from '@eop/shared';
 
 describe('<Threatbar>', () => {
   const selectedDiagram = 0;
@@ -49,28 +49,37 @@ describe('<Threatbar>', () => {
   };
 
   it('shows identified threats in reverse order', () => {
-    const model: ThreatDragonModel = {
+
+    const model: ThreatDragonModelV2 = {
+      version: '2.5.0',
       summary: {
         title: 'title',
       },
       detail: {
+        contributors: [],
         diagrams: [
           {
             id: 0,
-            diagramJson: {
-              cells: [
-                {
-                  size: { width: 0, height: 0 },
-                  position: { x: 0, y: 0 },
-                  angle: 0,
-                  z: 0,
-                  id: 'component1',
-                  type: 'tm.Actor',
-                  attrs: {
-                    text: {
-                      text: 'text',
-                    },
+            title: '',
+            diagramType: 'STRIDE',
+            thumbnail: '',
+            version: '2.5.0',
+            cells: [
+              {
+                id: 'component1',
+                shape: 'actor',
+                zIndex: 0,
+                position: { x: 0, y: 0 },
+                size: { width: 0, height: 0 },
+                angle: 0,
+                attrs: {
+                  text: {
+                    text: 'text',
                   },
+                },
+                data: {
+                  type: 'tm.Actor',
+                  name: 'text',            // aus attrs.text.text übernommen (du hattest keinen separaten Namen)
                   hasOpenThreats: true,
                   threats: [
                     {
@@ -91,14 +100,13 @@ describe('<Threatbar>', () => {
                     },
                   ],
                 },
-              ],
-            },
-            diagramType: 'STRIDE',
-            size: { width: 0, height: 0 },
-            thumbnail: '',
-            title: '',
+              },
+            ],
           },
         ],
+        diagramTop: 1,
+        reviewer: '',
+        threatTop: 2,
       },
     };
 
@@ -121,28 +129,40 @@ describe('<Threatbar>', () => {
   });
 
   it('shows existing threats in reverse order', () => {
-    const model: ThreatDragonModel = {
+
+    const model: ThreatDragonModelV2 = {
+      version: '2.5.0',
       summary: {
         title: 'title',
       },
       detail: {
+        contributors: [],
+        reviewer: '',
+        diagramTop: 1,
+        threatTop: 2,
         diagrams: [
           {
             id: 0,
-            diagramJson: {
-              cells: [
-                {
-                  size: { width: 0, height: 0 },
-                  position: { x: 0, y: 0 },
-                  angle: 0,
-                  z: 0,
-                  id: 'component1',
-                  type: 'tm.Actor',
-                  attrs: {
-                    text: {
-                      text: 'text',
-                    },
+            title: '',
+            diagramType: 'STRIDE',
+            thumbnail: '',
+            version: '2.5.0',
+            cells: [
+              {
+                id: 'component1',
+                shape: 'actor',             // aus type: "tm.Actor"
+                zIndex: 0,                  // aus z: 0
+                angle: 0,
+                position: { x: 0, y: 0 },
+                size: { width: 0, height: 0 },
+                attrs: {
+                  text: {
+                    text: 'text',
                   },
+                },
+                data: {
+                  type: 'tm.Actor',
+                  name: 'text',              // aus attrs.text.text übernommen
                   hasOpenThreats: true,
                   threats: [
                     {
@@ -163,16 +183,13 @@ describe('<Threatbar>', () => {
                     },
                   ],
                 },
-              ],
-            },
-            diagramType: 'STRIDE',
-            size: { width: 0, height: 0 },
-            thumbnail: '',
-            title: '',
+              },
+            ],
           },
         ],
       },
     };
+
 
     render(
       <Threatbar

--- a/apps/client/src/components/threatbar/threatbar.test.tsx
+++ b/apps/client/src/components/threatbar/threatbar.test.tsx
@@ -1,4 +1,4 @@
-import {GameMode, ModelType, ThreatDragonModelV2} from '@eop/shared';
+import { GameMode, ModelType, ThreatDragonModelV2 } from '@eop/shared';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
@@ -49,7 +49,6 @@ describe('<Threatbar>', () => {
   };
 
   it('shows identified threats in reverse order', () => {
-
     const model: ThreatDragonModelV2 = {
       version: '2.5.0',
       summary: {
@@ -79,7 +78,7 @@ describe('<Threatbar>', () => {
                 },
                 data: {
                   type: 'tm.Actor',
-                  name: 'text',            // aus attrs.text.text übernommen (du hattest keinen separaten Namen)
+                  name: 'text', // aus attrs.text.text übernommen (du hattest keinen separaten Namen)
                   hasOpenThreats: true,
                   threats: [
                     {
@@ -129,7 +128,6 @@ describe('<Threatbar>', () => {
   });
 
   it('shows existing threats in reverse order', () => {
-
     const model: ThreatDragonModelV2 = {
       version: '2.5.0',
       summary: {
@@ -150,8 +148,8 @@ describe('<Threatbar>', () => {
             cells: [
               {
                 id: 'component1',
-                shape: 'actor',             // aus type: "tm.Actor"
-                zIndex: 0,                  // aus z: 0
+                shape: 'actor', // aus type: "tm.Actor"
+                zIndex: 0, // aus z: 0
                 angle: 0,
                 position: { x: 0, y: 0 },
                 size: { width: 0, height: 0 },
@@ -162,7 +160,7 @@ describe('<Threatbar>', () => {
                 },
                 data: {
                   type: 'tm.Actor',
-                  name: 'text',              // aus attrs.text.text übernommen
+                  name: 'text', // aus attrs.text.text übernommen
                   hasOpenThreats: true,
                   threats: [
                     {
@@ -189,7 +187,6 @@ describe('<Threatbar>', () => {
         ],
       },
     };
-
 
     render(
       <Threatbar

--- a/apps/client/src/components/threatbar/threatbar.tsx
+++ b/apps/client/src/components/threatbar/threatbar.tsx
@@ -1,4 +1,8 @@
-import {getComponentName, getSuitDisplayName, ThreatDragonModelV2} from '@eop/shared';
+import {
+  getComponentName,
+  getSuitDisplayName,
+  ThreatDragonModelV2,
+} from '@eop/shared';
 import {
   faBolt,
   faEdit,
@@ -24,10 +28,7 @@ import ThreatModal from '../threatmodal/threatmodal';
 
 import './threatbar.css';
 
-import type {
-  GameState,
-  ThreatV2,
-} from '@eop/shared';
+import type { GameState, ThreatV2 } from '@eop/shared';
 import type { BoardProps } from 'boardgame.io/react';
 import type { FC } from 'react';
 import { Threat } from '../../../../../packages/shared/dist/types/game/threat';
@@ -41,15 +42,14 @@ type ThreatbarProps = {
 } & Pick<BoardProps<GameState>, 'G' | 'moves' | 'playerID'>;
 
 const Threatbar: FC<ThreatbarProps> = ({
-                                         playerID,
-                                         model,
-                                         G,
-                                         moves,
-                                         active,
-                                         names,
-                                         isInThreatStage,
-                                       }) => {
-
+  playerID,
+  model,
+  G,
+  moves,
+  active,
+  names,
+  isInThreatStage,
+}) => {
   const getSelectedComponent = () => {
     if (G.selectedComponent === '' || !model) {
       return undefined;
@@ -65,17 +65,19 @@ const Threatbar: FC<ThreatbarProps> = ({
     const component = getSelectedComponent();
 
     return (
-      component?.data?.threats?.map((threat: ThreatV2, index: number): Threat => ({
-        modal: false,
-        new: false,
-        owner: typeof threat.owner === 'string' ? threat.owner : undefined,
-        title: threat.title,
-        type: threat.type as Threat['type'],
-        severity: threat.severity,
-        description: threat.description,
-        mitigation: threat.mitigation,
-        id: threat.id ?? threat.threatId ?? `${index}`,
-      })) ?? []
+      component?.data?.threats?.map(
+        (threat: ThreatV2, index: number): Threat => ({
+          modal: false,
+          new: false,
+          owner: typeof threat.owner === 'string' ? threat.owner : undefined,
+          title: threat.title,
+          type: threat.type as Threat['type'],
+          severity: threat.severity,
+          description: threat.description,
+          mitigation: threat.mitigation,
+          id: threat.id ?? threat.threatId ?? `${index}`,
+        }),
+      ) ?? []
     );
   };
 

--- a/apps/client/src/jointjs/joint-tm.css
+++ b/apps/client/src/jointjs/joint-tm.css
@@ -29,6 +29,14 @@
   fill: red;
 }
 
+.marker-source.hasOpenThreats {
+  fill: red;
+}
+
+.marker-source.isUnidirectional {
+  display: none;
+}
+
 text.hasOpenThreats {
   stroke: none;
   fill: red;

--- a/apps/client/src/jointjs/shapes.js
+++ b/apps/client/src/jointjs/shapes.js
@@ -49,6 +49,7 @@ const Flow = dia.Link.extend({
     {
       type: 'tm.Flow',
       attrs: {
+        '.marker-source': { d: 'M 10 0 L 0 5 L 10 10 z' },
         '.marker-target': { d: 'M 10 0 L 0 5 L 10 10 z' },
       },
       smooth: true,
@@ -69,7 +70,7 @@ Object.defineProperty(Flow.prototype, 'name', {
 });
 
 defineOutOfScope(Flow.prototype, 'connection');
-defineHasOpenThreats(Flow.prototype, ['connection', 'marker-target']);
+defineHasOpenThreats(Flow.prototype, ['connection', 'marker-target', 'marker-source']);
 defineProperties(Flow.prototype, [
   'reasonOutOfScope',
   'protocol',
@@ -78,7 +79,7 @@ defineProperties(Flow.prototype, [
   'threats',
 ]);
 
-//trust boundary shape
+//trust boundary shapes
 
 const Boundary = dia.Link.extend({
   markup: [
@@ -111,7 +112,7 @@ const Boundary = dia.Link.extend({
       type: 'tm.Boundary',
       attrs: {
         '.connection': {
-          stroke: 'green',
+          stroke: 'black',
           'stroke-width': 3,
           'stroke-dasharray': '10,5',
         },
@@ -119,6 +120,57 @@ const Boundary = dia.Link.extend({
       smooth: true,
     },
     dia.Link.prototype.defaults,
+  ),
+});
+
+const BoundaryBox = shapes.basic.Generic.extend({
+  markup: [
+    '<g class="rotatable">' +
+      '<g class="scalable">' +
+      '<rect class="element-shape"/>' +
+      '<title class="tooltip"/></g>' +
+      '<text class="element-text"/></g>',
+  ].join(''),
+
+  setLabel: function (labelText) {
+    this.attributes.labels = [
+      {
+        position: 0.5,
+        attrs: {
+          text: { text: labelText, 'font-weight': '400', 'font-size': 'small' },
+        },
+      },
+    ];
+  },
+
+  defaults: util.defaultsDeep(
+    {
+      type: 'tm.BoundaryBox',
+      isTrustBoundary: true,
+      attrs: {
+        '.element-shape': {
+          fill: 'transparent',
+          stroke: 'black',
+          'stroke-width': 2,
+          'stroke-dasharray': '10,5',
+          'follow-scale': true,
+          width: 160,
+          height: 80,
+        },
+        text: {
+          'font-weight': 400,
+          'font-size': 'small',
+          fill: 'black',
+          'text-anchor': 'start',
+          'ref-x': 0.1,
+          'ref-y': 0.1,
+          'y-alignment': 'start',
+          ref: '.element-shape',
+        },
+      },
+      size: { width: 160, height: 80 },
+    },
+    shapes.basic.Generic.prototype.defaults,
   ),
 });
 
@@ -189,6 +241,19 @@ const Process = toolElement.extend({
         },
         text: { ref: '.element-shape' },
       },
+      size: { width: 100, height: 100 },
+    },
+    toolElement.prototype.defaults,
+  ),
+});
+
+const Text = toolElement.extend({
+  markup:
+    '<g class="rotatable"><g class="scalable"><title class="tooltip"/></g><text class="element-text hasNoOpenThreats isInScope"/></g>',
+
+  defaults: util.defaultsDeep(
+    {
+      type: 'tm.Text',
       size: { width: 100, height: 100 },
     },
     toolElement.prototype.defaults,
@@ -345,6 +410,8 @@ const ActorView = ToolElementView;
 
 const ProcessView = ToolElementView;
 
+const TextView = ToolElementView;
+
 const LinkView = dia.LinkView.extend({
   setSelected: function () {
     this.highlight(null, Highlighter);
@@ -358,14 +425,18 @@ const FlowView = LinkView;
 
 const BoundaryView = LinkView;
 
+const BoundaryBoxView = ToolElementView;
+
 const tm = {
   Highlighter,
   Flow,
   Boundary,
+  BoundaryBox,
   toolElement,
   Process,
   Store,
   Actor,
+  Text,
   ToolElementView,
   StoreView,
   ActorView,
@@ -373,6 +444,8 @@ const tm = {
   LinkView,
   FlowView,
   BoundaryView,
+  BoundaryBoxView,
+  TextView,
 };
 
 Object.assign(shapes, { tm });

--- a/apps/client/src/pages/about.tsx
+++ b/apps/client/src/pages/about.tsx
@@ -177,7 +177,7 @@ const About: FC = () => {
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="http://download.microsoft.com/download/F/A/E/FAE1434F-6D22-4581-9804-8B60C04354E4/EoP_Whitepaper.pdf"
+                    href="https://download.microsoft.com/download/F/A/E/FAE1434F-6D22-4581-9804-8B60C04354E4/EoP_Whitepaper.pdf"
                   >
                     EoP Whitepaper
                   </a>{' '}

--- a/apps/client/src/pages/create.tsx
+++ b/apps/client/src/pages/create.tsx
@@ -12,6 +12,7 @@ import {
   ModelType,
   SPECTATOR,
   Suit,
+  ThreatDragonModelV2,
 } from '@eop/shared';
 import { ChangeEvent, FC, useState } from 'react';
 import {
@@ -53,9 +54,7 @@ const Create: FC = () => {
   const [creating, setCreating] = useState(false);
   const [created, setCreated] = useState(false);
   const [modelType, setModelType] = useState(ModelType.IMAGE);
-  const [model, setModel] = useState<Record<string, unknown> | undefined>(
-    undefined,
-  );
+  const [model, setModel] = useState<ThreatDragonModelV2 | undefined>(undefined);
   const [image, setImage] = useState<File | undefined>(undefined);
   const [startSuit, setStartSuit] = useState<Suit>(DEFAULT_START_SUIT);
   const [turnDuration, setTurnDuration] = useState(DEFAULT_TURN_DURATION);
@@ -112,7 +111,7 @@ const Create: FC = () => {
       );
     }
 
-    setModel(JSON.parse(await readFileAsText(file)) as Record<string, unknown>);
+    setModel(JSON.parse(await readFileAsText(file)) as ThreatDragonModelV2);
   };
 
   const updateImage = (e: ChangeEvent<HTMLInputElement>) => {

--- a/apps/client/src/pages/create.tsx
+++ b/apps/client/src/pages/create.tsx
@@ -54,7 +54,9 @@ const Create: FC = () => {
   const [creating, setCreating] = useState(false);
   const [created, setCreated] = useState(false);
   const [modelType, setModelType] = useState(ModelType.IMAGE);
-  const [model, setModel] = useState<ThreatDragonModelV2 | undefined>(undefined);
+  const [model, setModel] = useState<ThreatDragonModelV2 | undefined>(
+    undefined,
+  );
   const [image, setImage] = useState<File | undefined>(undefined);
   const [startSuit, setStartSuit] = useState<Suit>(DEFAULT_START_SUIT);
   const [turnDuration, setTurnDuration] = useState(DEFAULT_TURN_DURATION);

--- a/apps/server/src/ModelFlatFile.ts
+++ b/apps/server/src/ModelFlatFile.ts
@@ -1,14 +1,14 @@
 import { FlatFile } from 'boardgame.io/server';
 
-import type { ThreatDragonModel } from '@eop/shared';
 import type { StorageAPI } from 'boardgame.io';
 import type { Object } from 'ts-toolbelt';
+import {ThreatDragonModelV2} from "@eop/shared";
 
 interface ModelFetchOpts extends StorageAPI.FetchOpts {
   model?: boolean;
 }
 
-type Model = ThreatDragonModel | { extension: string };
+type Model = ThreatDragonModelV2 | { extension: string };
 
 interface ModelFetchFields extends StorageAPI.FetchFields {
   model: Model | null;

--- a/apps/server/src/ModelFlatFile.ts
+++ b/apps/server/src/ModelFlatFile.ts
@@ -2,7 +2,7 @@ import { FlatFile } from 'boardgame.io/server';
 
 import type { StorageAPI } from 'boardgame.io';
 import type { Object } from 'ts-toolbelt';
-import {ThreatDragonModelV2} from "@eop/shared";
+import { ThreatDragonModelV2 } from '@eop/shared';
 
 interface ModelFetchOpts extends StorageAPI.FetchOpts {
   model?: boolean;

--- a/apps/server/src/endpoints.ts
+++ b/apps/server/src/endpoints.ts
@@ -13,8 +13,8 @@ import {
   ModelType,
   SetupData,
   SUITS,
-  ThreatDragonModel,
-  ThreatDragonThreat,
+  ThreatDragonModelV2,
+  ThreatV2,
 } from '@eop/shared';
 import { LobbyClient } from 'boardgame.io/client';
 import send from 'koa-send';
@@ -40,115 +40,113 @@ const createGameBodySchema = v.object({
 
 export const createGame =
   (gameServer: GameServer): IMiddleware =>
-  async (ctx) => {
-    const spectatorCredential = uuidv4();
+    async (ctx) => {
+      const spectatorCredential = uuidv4();
 
-    try {
-      // Create game
-      const body = v.parse(createGameBodySchema, ctx.request.body);
+      try {
+        // Create game
+        const body = v.parse(createGameBodySchema, ctx.request.body);
 
-      const lobbyClient = new LobbyClient({
-        server: `http://localhost:${INTERNAL_API_PORT}`,
-      });
+        const lobbyClient = new LobbyClient({
+          server: `http://localhost:${INTERNAL_API_PORT}`,
+        });
 
-      const { matchID } = await lobbyClient.createMatch(gameName, {
-        numPlayers: body.names.length,
-        setupData: {
-          startSuit: body.startSuit,
-          turnDuration: body.turnDuration,
-          gameMode: body.gameMode,
-          modelType: body.modelType,
-          modelReference: body.modelReference,
-          spectatorCredential,
-        } satisfies SetupData,
-      });
+        const { matchID } = await lobbyClient.createMatch(gameName, {
+          numPlayers: body.names.length,
+          setupData: {
+            startSuit: body.startSuit,
+            turnDuration: body.turnDuration,
+            gameMode: body.gameMode,
+            modelType: body.modelType,
+            modelReference: body.modelReference,
+            spectatorCredential,
+          } satisfies SetupData,
+        });
 
-      const credentials = [];
+        const credentials = [];
 
-      for (const [index, name] of body.names.entries()) {
-        const { playerCredentials } = await lobbyClient.joinMatch(
-          gameName,
-          matchID,
-          { playerID: index.toString(), playerName: name },
-        );
-
-        credentials.push(playerCredentials);
-      }
-
-      //model stuff
-      switch (body.modelType) {
-        case ModelType.THREAT_DRAGON: {
-          // TODO: validation
-          await gameServer.db.setModel(
+        for (const [index, name] of body.names.entries()) {
+          const { playerCredentials } = await lobbyClient.joinMatch(
+            gameName,
             matchID,
-            JSON.parse(body.model as string) as ThreatDragonModel,
+            { playerID: index.toString(), playerName: name },
           );
-          break;
+
+          credentials.push(playerCredentials);
         }
 
-        case ModelType.PRIVACY_ENHANCED: {
-          await gameServer.db.setModel(matchID, DEFAULT_MODEL);
-          break;
+        // model stuff
+        switch (body.modelType) {
+          case ModelType.THREAT_DRAGON: {
+            await gameServer.db.setModel(
+              matchID,
+              JSON.parse(body.model as string) as ThreatDragonModelV2,
+            );
+            break;
+          }
+
+          case ModelType.PRIVACY_ENHANCED: {
+            await gameServer.db.setModel(matchID, DEFAULT_MODEL);
+            break;
+          }
+
+          case ModelType.IMAGE: {
+            if (
+              !ctx.request.files ||
+              !ctx.request.files.model ||
+              Array.isArray(ctx.request.files.model)
+            ) {
+              throw Error('A single image needs to be provided');
+            }
+
+            if (!ctx.request.files.model.originalFilename) {
+              throw Error('No name specified for the provided image');
+            }
+
+            if (!ctx.request.files.model.mimetype) {
+              throw Error('No mime type specified for the provided image');
+            }
+
+            const extension = getImageExtension(
+              ctx.request.files.model.originalFilename,
+            );
+            if (
+              !(
+                /image\/[a-z+]+$/i.test(ctx.request.files.model.mimetype) &&
+                extension
+              )
+            ) {
+              throw Error('Filetype not supported');
+            }
+
+            await rename(
+              ctx.request.files.model.filepath,
+              `${getDbImagesFolder()}/${matchID}.${extension}`,
+            );
+            // use model object to store info about image
+            await gameServer.db.setModel(matchID, { extension });
+
+            break;
+          }
+
+          default: {
+            await gameServer.db.setModel(matchID, null);
+            break;
+          }
         }
 
-        case ModelType.IMAGE: {
-          if (
-            !ctx.request.files ||
-            !ctx.request.files.model ||
-            Array.isArray(ctx.request.files.model)
-          ) {
-            throw Error('A single image needs to be provided');
-          }
-
-          if (!ctx.request.files.model.originalFilename) {
-            throw Error('No name specified for the provided image');
-          }
-
-          if (!ctx.request.files.model.mimetype) {
-            throw Error('No mime type specified for the provided image');
-          }
-
-          const extension = getImageExtension(
-            ctx.request.files.model.originalFilename,
-          );
-          if (
-            !(
-              /image\/[a-z+]+$/i.test(ctx.request.files.model.mimetype) &&
-              extension
-            )
-          ) {
-            throw Error('Filetype not supported');
-          }
-
-          await rename(
-            ctx.request.files.model.filepath,
-            `${getDbImagesFolder()}/${matchID}.${extension}`,
-          );
-          //use model object to store info about image
-          await gameServer.db.setModel(matchID, { extension });
-
-          break;
-        }
-
-        default: {
-          await gameServer.db.setModel(matchID, null);
-          break;
-        }
+        logEvent(`Game created: ${matchID}`);
+        ctx.body = {
+          game: matchID,
+          credentials,
+          spectatorCredential,
+        };
+      } catch (err) {
+        const logArguments = err instanceof Error ? [err, err.stack] : [err];
+        console.error(...logArguments);
+        ctx.throw(500);
       }
-
-      logEvent(`Game created: ${matchID}`);
-      ctx.body = {
-        game: matchID,
-        credentials,
-        spectatorCredential,
-      };
-    } catch (err) {
-      // Maybe this error could be more specific?
-      const logArguments = err instanceof Error ? [err, err.stack] : [err];
-      console.error(...logArguments);
-      ctx.throw(500);
-    }
-  };
+    };
 
 // TODO: This returns more than just the players: It returns the requested match. We should probably adjust the name (and the path). See https://boardgame.io/documentation/#/api/Lobby?id=getting-a-specific-match-by-its-id
 export const getPlayerNames = (): IMiddleware => async (ctx) => {
@@ -166,39 +164,39 @@ export const getPlayerNames = (): IMiddleware => async (ctx) => {
 
 export const getModel =
   (gameServer: GameServer): IMiddleware =>
-  async (ctx) => {
-    const matchID = ctx.params.matchID;
-    if (matchID === undefined) {
-      return ctx.throw('Missing required parameter matchID', 400);
-    }
+    async (ctx) => {
+      const matchID = ctx.params.matchID;
+      if (matchID === undefined) {
+        return ctx.throw('Missing required parameter matchID', 400);
+      }
 
-    const game = await gameServer.db.fetch(matchID, { model: true });
+      const game = await gameServer.db.fetch(matchID, { model: true });
 
-    ctx.body = game.model;
-  };
+      ctx.body = game.model;
+    };
 
 export const getImage =
   (gameServer: GameServer): IMiddleware =>
-  async (ctx) => {
-    const matchID = ctx.params.matchID;
-    if (matchID === undefined) {
-      return ctx.throw('Missing required parameter matchID', 400);
-    }
+    async (ctx) => {
+      const matchID = ctx.params.matchID;
+      if (matchID === undefined) {
+        return ctx.throw('Missing required parameter matchID', 400);
+      }
 
-    const game = await gameServer.db.fetch(matchID, { model: true });
+      const game = await gameServer.db.fetch(matchID, { model: true });
 
-    if (!game.model || !('extension' in game.model)) {
-      return ctx.throw(
-        'Cannot request image if none is stored, maybe the wrong model type has been set?',
-        400,
-      );
-    }
+      if (!game.model || !('extension' in game.model)) {
+        return ctx.throw(
+          'Cannot request image if none is stored, maybe the wrong model type has been set?',
+          400,
+        );
+      }
 
     //send image
-    await send(ctx, `${matchID}.${game.model?.extension}`, {
-      root: getDbImagesFolder(),
-    });
-  };
+      await send(ctx, `${matchID}.${game.model?.extension}`, {
+        root: getDbImagesFolder(),
+      });
+    };
 
 const getMethodologyName = (gameMode: GameMode) => {
   if (gameMode === GameMode.EOP) {
@@ -207,7 +205,6 @@ const getMethodologyName = (gameMode: GameMode) => {
   if (gameMode === GameMode.CORNUCOPIA) {
     return 'Cornucopia';
   }
-
   if (gameMode === GameMode.CUMULUS) {
     return 'Cumulus';
   }
@@ -217,49 +214,53 @@ const getMethodologyName = (gameMode: GameMode) => {
 
 export const downloadThreatDragonModel =
   (gameServer: GameServer): IMiddleware =>
-  async (ctx) => {
-    const matchID = ctx.params.matchID;
-    if (matchID === undefined) {
-      return ctx.throw('Missing required parameter matchID', 400);
-    }
-
-    const game = await gameServer.db.fetch(matchID, {
-      state: true,
-      metadata: true,
-      model: true,
-    });
-
-    const state = game.state as State<GameState>;
-
-    const isJsonModel =
-      state.G.modelType == ModelType.PRIVACY_ENHANCED ||
-      state.G.modelType == ModelType.THREAT_DRAGON;
-
-    const model = game.model;
-    if (!model || 'extension' in model || !isJsonModel) {
-      // if in wrong modelType
-      return ctx.throw(
-        'Cannot download model if none is set, maybe the wrong model type has been set?',
-        400,
-      );
-    }
-
-    // update the model with the identified threats
-    state.G.identifiedThreats.forEach((threatsForComponent, diagramIdx) => {
-      if (threatsForComponent === null) {
-        return;
+    async (ctx) => {
+      const matchID = ctx.params.matchID;
+      if (matchID === undefined) {
+        return ctx.throw('Missing required parameter matchID', 400);
       }
-      Object.keys(threatsForComponent).forEach((componentIdx) => {
-        const diagram = model.detail.diagrams[diagramIdx]?.diagramJson;
-        const cell = diagram?.cells?.find((c) => c.id === componentIdx);
 
-        if (
-          cell !== undefined &&
-          threatsForComponent[componentIdx] !== undefined
-        ) {
-          const threats: ThreatDragonThreat[] = cell.threats ?? [];
-          Object.values(threatsForComponent[componentIdx]).forEach((t) =>
-            threats.push({
+      const game = await gameServer.db.fetch(matchID, {
+        state: true,
+        metadata: true,
+        model: true,
+      });
+
+      const state = game.state as State<GameState>;
+
+      const isJsonModel =
+        state.G.modelType == ModelType.PRIVACY_ENHANCED ||
+        state.G.modelType == ModelType.THREAT_DRAGON;
+
+      const model = game.model;
+      if (!model || 'extension' in model || !isJsonModel) {
+        // if in wrong modelType
+        return ctx.throw(
+          'Cannot download model if none is set, maybe the wrong model type has been set?',
+          400,
+        );
+      }
+
+      const tdModel: ThreatDragonModelV2 = model
+
+      // update the model with the identified threats
+      state.G.identifiedThreats.forEach((threatsForComponent, diagramIdx) => {
+        if (threatsForComponent === null) return;
+
+        const diagram = tdModel.detail.diagrams[diagramIdx];
+        if (!diagram) return;
+
+        Object.keys(threatsForComponent).forEach((componentId) => {
+          const cell = diagram.cells?.find((c) => c.id === componentId);
+          if (!cell) return;
+
+          const threatsInGame = threatsForComponent[componentId];
+          if (!threatsInGame) return;
+
+          const existing: ThreatV2[] = cell.data.threats ?? [];
+
+          Object.values(threatsInGame).forEach((t) => {
+            existing.push({
               description: t.description ?? '',
               mitigation: t.mitigation ?? '',
               modelType: getMethodologyName(state.G.gameMode),
@@ -267,84 +268,84 @@ export const downloadThreatDragonModel =
               status: 'Open',
               title: t.title ?? '',
               type: getSuitDisplayName(state.G.gameMode, t.type),
-
               owner:
                 t.owner !== undefined
                   ? game.metadata.players[Number.parseInt(t.owner)]?.name
                   : undefined,
               id: t.id,
               game: matchID,
-            }),
-          );
-          cell.threats = threats;
-        }
+            });
+          });
+
+          cell.data.threats = existing;
+          cell.data.hasOpenThreats =
+            cell.data.hasOpenThreats || existing.some((x) => x.status === 'Open');
+        });
       });
-    });
 
-    const modelTitle = model.summary.title.replace(' ', '-');
-    const timestamp = new Date().toISOString().replace(':', '-');
-    const filename = `${modelTitle}-${timestamp}.json`;
+      const modelTitle = tdModel.summary.title.replace(' ', '-');
+      const timestamp = new Date().toISOString().replace(':', '-');
+      const filename = `${modelTitle}-${timestamp}.json`;
 
-    logEvent(`Download model: ${matchID}`);
-    ctx.attachment(filename);
-    ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
-    ctx.body = game.model;
-  };
+      logEvent(`Download model: ${matchID}`);
+      ctx.attachment(filename);
+      ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
+      ctx.body = tdModel;
+    };
 
 export const downloadThreatsMarkdownFile =
   (gameServer: GameServer): IMiddleware =>
-  async (ctx) => {
-    //get some variables that might be useful
-    const matchID = ctx.params.matchID;
-    if (matchID === undefined) {
-      return ctx.throw('Missing required parameter matchID', 400);
-    }
-    const game = await gameServer.db.fetch(matchID, {
-      state: true,
-      metadata: true,
-      model: true,
-    });
+    async (ctx) => {
+      //get some variables that might be useful
+      const matchID = ctx.params.matchID;
+      if (matchID === undefined) {
+        return ctx.throw('Missing required parameter matchID', 400);
+      }
 
-    const state = game.state as State<GameState>;
+      const game = await gameServer.db.fetch(matchID, {
+        state: true,
+        metadata: true,
+        model: true,
+      });
 
-    const isJsonModel =
-      state.G.modelType == ModelType.PRIVACY_ENHANCED ||
-      state.G.modelType == ModelType.THREAT_DRAGON;
+      const state = game.state as State<GameState>;
 
-    const model = game.model;
-    const threats = getThreats(
-      state,
-      game.metadata,
-      isJsonModel && model && !('extension' in model) ? model : null,
-    );
+      const isJsonModel =
+        state.G.modelType == ModelType.PRIVACY_ENHANCED ||
+        state.G.modelType == ModelType.THREAT_DRAGON;
 
-    const modelTitle =
-      isJsonModel && game.model && !('extension' in game.model)
-        ? game.model
-          ? game.model?.summary.title.trim().replaceAll(' ', '-')
-          : ``
-        : state.G.gameMode
-          ? state.G.gameMode.trim().replaceAll(' ', '')
-          : ``;
-    const timestamp = new Date().toISOString().replaceAll(':', '-');
-    const date = new Date().toLocaleString();
-    const filename = `threats-${modelTitle}-${timestamp}.md`;
+      const model: ThreatDragonModelV2 | null = game.model as ThreatDragonModelV2;
 
-    logEvent(`Download threats: ${matchID}`);
-    ctx.attachment(filename);
-    ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
-    ctx.body = formatThreats(
-      threats.map((threat) =>
-        enrichThreatWithCategory(threat, state.G.gameMode),
-      ),
-      date,
-    );
-  };
+      const threats = getThreats(
+        state,
+        game.metadata,
+        isJsonModel && model && !('extension' in model) ? model : null,
+      );
 
-type ThreatWithCategory = ThreatDragonThreat & { category?: string };
+      const modelTitle =
+        isJsonModel && game.model && !('extension' in game.model)
+          ? game.model.summary.title.trim().replaceAll(' ', '-')
+          : state.G.gameMode
+            ? state.G.gameMode.trim().replaceAll(' ', '')
+            : ``;
+
+      const timestamp = new Date().toISOString().replaceAll(':', '-');
+      const date = new Date().toLocaleString();
+      const filename = `threats-${modelTitle}-${timestamp}.md`;
+
+      logEvent(`Download threats: ${matchID}`);
+      ctx.attachment(filename);
+      ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
+      ctx.body = formatThreats(
+        threats.map((threat) => enrichThreatWithCategory(threat, state.G.gameMode)),
+        date,
+      );
+    };
+
+type ThreatWithCategory = ThreatV2 & { category?: string; owner?: string };
 
 function enrichThreatWithCategory(
-  threat: ThreatDragonThreat,
+  threat: ThreatV2,
   gameMode: GameMode,
 ): ThreatWithCategory {
   if (threat.type) {
@@ -362,16 +363,17 @@ function enrichThreatWithCategory(
 function getThreats(
   gameState: State<GameState>,
   metadata: Server.MatchData,
-  model: ThreatDragonModel | null,
+  model: ThreatDragonModelV2 | null,
 ) {
-  const threats: ThreatDragonThreat[] = [];
+  const threats: ThreatV2[] = [];
 
-  //add threats from G.identifiedThreats
+  // add threats from G.identifiedThreats
   gameState.G.identifiedThreats.forEach((identifiedThreats) => {
     if (identifiedThreats !== null) {
       Object.keys(identifiedThreats).forEach((componentId) => {
         if (identifiedThreats[componentId] !== undefined) {
           Object.values(identifiedThreats[componentId]).forEach((threat) => {
+            //const t = threat as Partial<ThreatV2> & { owner?: string };
             threats.push({
               ...threat,
               owner:
@@ -391,12 +393,13 @@ function getThreats(
     }
   });
 
-  //add threats from model
+  // add threats from model
   if (model) {
     model.detail.diagrams.forEach((diagram) => {
-      diagram.diagramJson.cells?.forEach((cell) => {
-        if (cell.threats !== undefined) {
-          threats.push(...cell.threats);
+      diagram.cells?.forEach((cell) => {
+        const t = cell.data?.threats;
+        if (Array.isArray(t) && t.length) {
+          threats.push(...t);
         }
       });
     });

--- a/apps/server/src/endpoints.ts
+++ b/apps/server/src/endpoints.ts
@@ -40,113 +40,114 @@ const createGameBodySchema = v.object({
 
 export const createGame =
   (gameServer: GameServer): IMiddleware =>
-    async (ctx) => {
-      const spectatorCredential = uuidv4();
+  async (ctx) => {
+    const spectatorCredential = uuidv4();
 
-      try {
-        // Create game
-        const body = v.parse(createGameBodySchema, ctx.request.body);
+    try {
+      // Create game
+      const body = v.parse(createGameBodySchema, ctx.request.body);
 
-        const lobbyClient = new LobbyClient({
-          server: `http://localhost:${INTERNAL_API_PORT}`,
-        });
+      const lobbyClient = new LobbyClient({
+        server: `http://localhost:${INTERNAL_API_PORT}`,
+      });
 
-        const { matchID } = await lobbyClient.createMatch(gameName, {
-          numPlayers: body.names.length,
-          setupData: {
-            startSuit: body.startSuit,
-            turnDuration: body.turnDuration,
-            gameMode: body.gameMode,
-            modelType: body.modelType,
-            modelReference: body.modelReference,
-            spectatorCredential,
-          } satisfies SetupData,
-        });
-
-        const credentials = [];
-
-        for (const [index, name] of body.names.entries()) {
-          const { playerCredentials } = await lobbyClient.joinMatch(
-            gameName,
-            matchID,
-            { playerID: index.toString(), playerName: name },
-          );
-
-          credentials.push(playerCredentials);
-        }
-
-        // model stuff
-        switch (body.modelType) {
-          case ModelType.THREAT_DRAGON: {
-            await gameServer.db.setModel(
-              matchID,
-              JSON.parse(body.model as string) as ThreatDragonModelV2,
-            );
-            break;
-          }
-
-          case ModelType.PRIVACY_ENHANCED: {
-            await gameServer.db.setModel(matchID, DEFAULT_MODEL);
-            break;
-          }
-
-          case ModelType.IMAGE: {
-            if (
-              !ctx.request.files ||
-              !ctx.request.files.model ||
-              Array.isArray(ctx.request.files.model)
-            ) {
-              throw Error('A single image needs to be provided');
-            }
-
-            if (!ctx.request.files.model.originalFilename) {
-              throw Error('No name specified for the provided image');
-            }
-
-            if (!ctx.request.files.model.mimetype) {
-              throw Error('No mime type specified for the provided image');
-            }
-
-            const extension = getImageExtension(
-              ctx.request.files.model.originalFilename,
-            );
-            if (
-              !(
-                /image\/[a-z+]+$/i.test(ctx.request.files.model.mimetype) &&
-                extension
-              )
-            ) {
-              throw Error('Filetype not supported');
-            }
-
-            await rename(
-              ctx.request.files.model.filepath,
-              `${getDbImagesFolder()}/${matchID}.${extension}`,
-            );
-            // use model object to store info about image
-            await gameServer.db.setModel(matchID, { extension });
-
-            break;
-          }
-
-          default: {
-            await gameServer.db.setModel(matchID, null);
-            break;
-          }
-        }
-
-        logEvent(`Game created: ${matchID}`);
-        ctx.body = {
-          game: matchID,
-          credentials,
+      const { matchID } = await lobbyClient.createMatch(gameName, {
+        numPlayers: body.names.length,
+        setupData: {
+          startSuit: body.startSuit,
+          turnDuration: body.turnDuration,
+          gameMode: body.gameMode,
+          modelType: body.modelType,
+          modelReference: body.modelReference,
           spectatorCredential,
-        };
-      } catch (err) {
-        const logArguments = err instanceof Error ? [err, err.stack] : [err];
-        console.error(...logArguments);
-        ctx.throw(500);
+        } satisfies SetupData,
+      });
+
+      const credentials = [];
+
+      for (const [index, name] of body.names.entries()) {
+        const { playerCredentials } = await lobbyClient.joinMatch(
+          gameName,
+          matchID,
+          { playerID: index.toString(), playerName: name },
+        );
+
+        credentials.push(playerCredentials);
       }
-    };
+
+      // model stuff
+      switch (body.modelType) {
+        case ModelType.THREAT_DRAGON: {
+          await gameServer.db.setModel(
+            matchID,
+            JSON.parse(body.model as string) as ThreatDragonModelV2,
+          );
+          break;
+        }
+
+        case ModelType.PRIVACY_ENHANCED: {
+          await gameServer.db.setModel(matchID, DEFAULT_MODEL);
+          break;
+        }
+
+        case ModelType.IMAGE: {
+          if (
+            !ctx.request.files ||
+            !ctx.request.files.model ||
+            Array.isArray(ctx.request.files.model)
+          ) {
+            throw Error('A single image needs to be provided');
+          }
+
+          if (!ctx.request.files.model.originalFilename) {
+            throw Error('No name specified for the provided image');
+          }
+
+          if (!ctx.request.files.model.mimetype) {
+            throw Error('No mime type specified for the provided image');
+          }
+
+          const extension = getImageExtension(
+            ctx.request.files.model.originalFilename,
+          );
+          if (
+            !(
+              /image\/[a-z+]+$/i.test(ctx.request.files.model.mimetype) &&
+              extension
+            )
+          ) {
+            throw Error('Filetype not supported');
+          }
+
+          await rename(
+            ctx.request.files.model.filepath,
+            `${getDbImagesFolder()}/${matchID}.${extension}`,
+          );
+          // use model object to store info about image
+          await gameServer.db.setModel(matchID, { extension });
+
+          break;
+        }
+
+        default: {
+          await gameServer.db.setModel(matchID, null);
+          break;
+        }
+      }
+
+      logEvent(`Game created: ${matchID}`);
+      ctx.body = {
+        game: matchID,
+        credentials,
+        spectatorCredential,
+      };
+    } catch (err) {
+      // Maybe this error could be more specific?
+      const logArguments = err instanceof Error ? [err, err.stack] : [err];
+      console.error(...logArguments);
+      ctx.throw(500);
+    }
+  };
 
 // TODO: This returns more than just the players: It returns the requested match. We should probably adjust the name (and the path). See https://boardgame.io/documentation/#/api/Lobby?id=getting-a-specific-match-by-its-id
 export const getPlayerNames = (): IMiddleware => async (ctx) => {
@@ -164,39 +165,39 @@ export const getPlayerNames = (): IMiddleware => async (ctx) => {
 
 export const getModel =
   (gameServer: GameServer): IMiddleware =>
-    async (ctx) => {
-      const matchID = ctx.params.matchID;
-      if (matchID === undefined) {
-        return ctx.throw('Missing required parameter matchID', 400);
-      }
+  async (ctx) => {
+    const matchID = ctx.params.matchID;
+    if (matchID === undefined) {
+      return ctx.throw('Missing required parameter matchID', 400);
+    }
 
-      const game = await gameServer.db.fetch(matchID, { model: true });
+    const game = await gameServer.db.fetch(matchID, { model: true });
 
-      ctx.body = game.model;
-    };
+    ctx.body = game.model;
+  };
 
 export const getImage =
   (gameServer: GameServer): IMiddleware =>
-    async (ctx) => {
-      const matchID = ctx.params.matchID;
-      if (matchID === undefined) {
-        return ctx.throw('Missing required parameter matchID', 400);
-      }
+  async (ctx) => {
+    const matchID = ctx.params.matchID;
+    if (matchID === undefined) {
+      return ctx.throw('Missing required parameter matchID', 400);
+    }
 
-      const game = await gameServer.db.fetch(matchID, { model: true });
+    const game = await gameServer.db.fetch(matchID, { model: true });
 
-      if (!game.model || !('extension' in game.model)) {
-        return ctx.throw(
-          'Cannot request image if none is stored, maybe the wrong model type has been set?',
-          400,
-        );
-      }
+    if (!game.model || !('extension' in game.model)) {
+      return ctx.throw(
+        'Cannot request image if none is stored, maybe the wrong model type has been set?',
+        400,
+      );
+    }
 
     //send image
-      await send(ctx, `${matchID}.${game.model?.extension}`, {
-        root: getDbImagesFolder(),
-      });
-    };
+    await send(ctx, `${matchID}.${game.model?.extension}`, {
+      root: getDbImagesFolder(),
+    });
+  };
 
 const getMethodologyName = (gameMode: GameMode) => {
   if (gameMode === GameMode.EOP) {
@@ -214,133 +215,135 @@ const getMethodologyName = (gameMode: GameMode) => {
 
 export const downloadThreatDragonModel =
   (gameServer: GameServer): IMiddleware =>
-    async (ctx) => {
-      const matchID = ctx.params.matchID;
-      if (matchID === undefined) {
-        return ctx.throw('Missing required parameter matchID', 400);
-      }
+  async (ctx) => {
+    const matchID = ctx.params.matchID;
+    if (matchID === undefined) {
+      return ctx.throw('Missing required parameter matchID', 400);
+    }
 
-      const game = await gameServer.db.fetch(matchID, {
-        state: true,
-        metadata: true,
-        model: true,
-      });
+    const game = await gameServer.db.fetch(matchID, {
+      state: true,
+      metadata: true,
+      model: true,
+    });
 
-      const state = game.state as State<GameState>;
+    const state = game.state as State<GameState>;
 
-      const isJsonModel =
-        state.G.modelType == ModelType.PRIVACY_ENHANCED ||
-        state.G.modelType == ModelType.THREAT_DRAGON;
+    const isJsonModel =
+      state.G.modelType == ModelType.PRIVACY_ENHANCED ||
+      state.G.modelType == ModelType.THREAT_DRAGON;
 
-      const model = game.model;
-      if (!model || 'extension' in model || !isJsonModel) {
-        // if in wrong modelType
-        return ctx.throw(
-          'Cannot download model if none is set, maybe the wrong model type has been set?',
-          400,
-        );
-      }
+    const model = game.model;
+    if (!model || 'extension' in model || !isJsonModel) {
+      // if in wrong modelType
+      return ctx.throw(
+        'Cannot download model if none is set, maybe the wrong model type has been set?',
+        400,
+      );
+    }
 
-      const tdModel: ThreatDragonModelV2 = model
+    const tdModel: ThreatDragonModelV2 = model;
 
-      // update the model with the identified threats
-      state.G.identifiedThreats.forEach((threatsForComponent, diagramIdx) => {
-        if (threatsForComponent === null) return;
+    // update the model with the identified threats
+    state.G.identifiedThreats.forEach((threatsForComponent, diagramIdx) => {
+      if (threatsForComponent === null) return;
 
-        const diagram = tdModel.detail.diagrams[diagramIdx];
-        if (!diagram) return;
+      const diagram = tdModel.detail.diagrams[diagramIdx];
+      if (!diagram) return;
 
-        Object.keys(threatsForComponent).forEach((componentId) => {
-          const cell = diagram.cells?.find((c) => c.id === componentId);
-          if (!cell) return;
+      Object.keys(threatsForComponent).forEach((componentId) => {
+        const cell = diagram.cells?.find((c) => c.id === componentId);
+        if (!cell) return;
 
-          const threatsInGame = threatsForComponent[componentId];
-          if (!threatsInGame) return;
+        const threatsInGame = threatsForComponent[componentId];
+        if (!threatsInGame) return;
 
-          const existing: ThreatV2[] = cell.data.threats ?? [];
+        const existing: ThreatV2[] = cell.data.threats ?? [];
 
-          Object.values(threatsInGame).forEach((t) => {
-            existing.push({
-              description: t.description ?? '',
-              mitigation: t.mitigation ?? '',
-              modelType: getMethodologyName(state.G.gameMode),
-              severity: t.severity ?? '',
-              status: 'Open',
-              title: t.title ?? '',
-              type: getSuitDisplayName(state.G.gameMode, t.type),
-              owner:
-                t.owner !== undefined
-                  ? game.metadata.players[Number.parseInt(t.owner)]?.name
-                  : undefined,
-              id: t.id,
-              game: matchID,
-            });
+        Object.values(threatsInGame).forEach((t) => {
+          existing.push({
+            description: t.description ?? '',
+            mitigation: t.mitigation ?? '',
+            modelType: getMethodologyName(state.G.gameMode),
+            severity: t.severity ?? '',
+            status: 'Open',
+            title: t.title ?? '',
+            type: getSuitDisplayName(state.G.gameMode, t.type),
+            owner:
+              t.owner !== undefined
+                ? game.metadata.players[Number.parseInt(t.owner)]?.name
+                : undefined,
+            id: t.id,
+            game: matchID,
           });
-
-          cell.data.threats = existing;
-          cell.data.hasOpenThreats =
-            cell.data.hasOpenThreats || existing.some((x) => x.status === 'Open');
         });
+
+        cell.data.threats = existing;
+        cell.data.hasOpenThreats =
+          cell.data.hasOpenThreats || existing.some((x) => x.status === 'Open');
       });
+    });
 
-      const modelTitle = tdModel.summary.title.replace(' ', '-');
-      const timestamp = new Date().toISOString().replace(':', '-');
-      const filename = `${modelTitle}-${timestamp}.json`;
+    const modelTitle = tdModel.summary.title.replace(' ', '-');
+    const timestamp = new Date().toISOString().replace(':', '-');
+    const filename = `${modelTitle}-${timestamp}.json`;
 
-      logEvent(`Download model: ${matchID}`);
-      ctx.attachment(filename);
-      ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
-      ctx.body = tdModel;
-    };
+    logEvent(`Download model: ${matchID}`);
+    ctx.attachment(filename);
+    ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
+    ctx.body = tdModel;
+  };
 
 export const downloadThreatsMarkdownFile =
   (gameServer: GameServer): IMiddleware =>
-    async (ctx) => {
-      //get some variables that might be useful
-      const matchID = ctx.params.matchID;
-      if (matchID === undefined) {
-        return ctx.throw('Missing required parameter matchID', 400);
-      }
+  async (ctx) => {
+    //get some variables that might be useful
+    const matchID = ctx.params.matchID;
+    if (matchID === undefined) {
+      return ctx.throw('Missing required parameter matchID', 400);
+    }
 
-      const game = await gameServer.db.fetch(matchID, {
-        state: true,
-        metadata: true,
-        model: true,
-      });
+    const game = await gameServer.db.fetch(matchID, {
+      state: true,
+      metadata: true,
+      model: true,
+    });
 
-      const state = game.state as State<GameState>;
+    const state = game.state as State<GameState>;
 
-      const isJsonModel =
-        state.G.modelType == ModelType.PRIVACY_ENHANCED ||
-        state.G.modelType == ModelType.THREAT_DRAGON;
+    const isJsonModel =
+      state.G.modelType == ModelType.PRIVACY_ENHANCED ||
+      state.G.modelType == ModelType.THREAT_DRAGON;
 
-      const model: ThreatDragonModelV2 | null = game.model as ThreatDragonModelV2;
+    const model: ThreatDragonModelV2 | null = game.model as ThreatDragonModelV2;
 
-      const threats = getThreats(
-        state,
-        game.metadata,
-        isJsonModel && model && !('extension' in model) ? model : null,
-      );
+    const threats = getThreats(
+      state,
+      game.metadata,
+      isJsonModel && model && !('extension' in model) ? model : null,
+    );
 
-      const modelTitle =
-        isJsonModel && game.model && !('extension' in game.model)
-          ? game.model.summary.title.trim().replaceAll(' ', '-')
-          : state.G.gameMode
-            ? state.G.gameMode.trim().replaceAll(' ', '')
-            : ``;
+    const modelTitle =
+      isJsonModel && game.model && !('extension' in game.model)
+        ? game.model.summary.title.trim().replaceAll(' ', '-')
+        : state.G.gameMode
+          ? state.G.gameMode.trim().replaceAll(' ', '')
+          : ``;
 
-      const timestamp = new Date().toISOString().replaceAll(':', '-');
-      const date = new Date().toLocaleString();
-      const filename = `threats-${modelTitle}-${timestamp}.md`;
+    const timestamp = new Date().toISOString().replaceAll(':', '-');
+    const date = new Date().toLocaleString();
+    const filename = `threats-${modelTitle}-${timestamp}.md`;
 
-      logEvent(`Download threats: ${matchID}`);
-      ctx.attachment(filename);
-      ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
-      ctx.body = formatThreats(
-        threats.map((threat) => enrichThreatWithCategory(threat, state.G.gameMode)),
-        date,
-      );
-    };
+    logEvent(`Download threats: ${matchID}`);
+    ctx.attachment(filename);
+    ctx.set('Access-Control-Expose-Headers', 'Content-Disposition');
+    ctx.body = formatThreats(
+      threats.map((threat) =>
+        enrichThreatWithCategory(threat, state.G.gameMode),
+      ),
+      date,
+    );
+  };
 
 type ThreatWithCategory = ThreatV2 & { category?: string; owner?: string };
 
@@ -373,7 +376,6 @@ function getThreats(
       Object.keys(identifiedThreats).forEach((componentId) => {
         if (identifiedThreats[componentId] !== undefined) {
           Object.values(identifiedThreats[componentId]).forEach((threat) => {
-            //const t = threat as Partial<ThreatV2> & { owner?: string };
             threats.push({
               ...threat,
               owner:

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -18,7 +18,7 @@ import {
   publicApiServerHandle,
 } from './main';
 
-import type { ThreatDragonModel } from '@eop/shared';
+import type { ThreatDragonModelV2 } from '@eop/shared';
 import type { LobbyAPI, Server, State } from 'boardgame.io';
 
 beforeEach(() => {
@@ -192,43 +192,56 @@ it('download the final model for a game', async () => {
     updatedAt: 0,
   };
 
-  const model: ThreatDragonModel = {
+
+  const model: ThreatDragonModelV2 = {
+    version: '2.5.0',
     summary: {
       title: 'Foo',
     },
     detail: {
+      contributors: [],
+      reviewer: '',
+      diagramTop: 1,
+      threatTop: 0,
       diagrams: [
         {
           id: 0,
-          diagramJson: {
-            cells: [
-              {
-                id: 'component-1',
+          title: '',
+          diagramType: 'STRIDE',
+          thumbnail: '',
+          version: '2.5.0',
+          cells: [
+            {
+              id: 'component-1',
+              shape: 'actor',          // V2 shape derived from tm.Actor
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              angle: 0,
+              attrs: {},
+              data: {
                 type: 'tm.Actor',
+                name: '',
                 hasOpenThreats: false,
                 threats: [],
-                size: { height: 0, width: 0 },
-                attrs: {},
-                angle: 0,
-                position: { x: 0, y: 0 },
-                z: 0,
               },
-              {
-                id: 'component-2',
+            },
+            {
+              id: 'component-2',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              angle: 0,
+              attrs: {},
+              data: {
                 type: 'tm.Actor',
+                name: '',
                 hasOpenThreats: false,
-                size: { height: 0, width: 0 },
-                attrs: {},
-                angle: 0,
-                position: { x: 0, y: 0 },
-                z: 0,
+                threats: [],
               },
-            ],
-          },
-          diagramType: 'STRIDE',
-          size: { width: 0, height: 0 },
-          thumbnail: '',
-          title: '',
+            },
+          ],
         },
       ],
     },
@@ -243,8 +256,8 @@ it('download the final model for a game', async () => {
     .get(`/game/${matchID}/download`)
     .auth('0', 'abc123');
 
-  const body = response.body as ThreatDragonModel;
-  const threats = body.detail.diagrams[0]?.diagramJson.cells?.[0]?.threats;
+  const body = response.body as ThreatDragonModelV2;
+  const threats = body.detail.diagrams[0]?.cells?.[0]?.data?.threats;
 
   expect(threats?.[0]?.id).toBe('0');
   expect(threats?.[0]?.type).toBe('Spoofing');
@@ -303,17 +316,37 @@ it('Download threat file', async () => {
   } as State;
 
   //Maybe I should put these jsons into a file
-  const model: ThreatDragonModel = {
+
+
+  const model: ThreatDragonModelV2 = {
+    version: '2.5.0',
     summary: {
       title: '  Demo Threat Model ',
     },
     detail: {
+      contributors: [],
+      reviewer: '',
+      diagramTop: 1,
+      threatTop: 4,
       diagrams: [
         {
           id: 0,
-          diagramJson: {
-            cells: [
-              {
+          title: '',
+          diagramType: 'STRIDE',
+          thumbnail: '',
+          version: '2.5.0',
+          cells: [
+            {
+              id: '00000000-0000-0000-0000-000000000001',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
+                type: 'tm.Actor',
+                name: '',
+                hasOpenThreats: true,
                 threats: [
                   {
                     status: 'Open',
@@ -325,16 +358,19 @@ it('Download threat file', async () => {
                     type: 'Information disclosure',
                   },
                 ],
-                hasOpenThreats: true,
-                angle: 0,
-                attrs: {},
-                id: '',
-                position: { x: 0, y: 0 },
-                size: { height: 0, width: 0 },
-                type: 'tm.Actor',
-                z: 0,
               },
-              {
+            },
+            {
+              id: '00000000-0000-0000-0000-000000000002',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
+                type: 'tm.Actor',
+                name: '',
+                hasOpenThreats: true,
                 threats: [
                   {
                     status: 'Mitigated',
@@ -357,16 +393,19 @@ it('Download threat file', async () => {
                     owner: 'The Model',
                   },
                 ],
-                hasOpenThreats: true,
-                angle: 0,
-                attrs: {},
-                id: '',
-                position: { x: 0, y: 0 },
-                size: { height: 0, width: 0 },
-                type: 'tm.Actor',
-                z: 0,
               },
-              {
+            },
+            {
+              id: '00000000-0000-0000-0000-000000000003',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
+                type: 'tm.Actor',
+                name: '',
+                hasOpenThreats: false,
                 threats: [
                   {
                     status: 'Open',
@@ -380,41 +419,37 @@ it('Download threat file', async () => {
                       "The Message Queue credentials should be encrypted.\n\n\n\n\nnewlines shouldn't\nbreak the formatting",
                   },
                 ],
-                hasOpenThreats: false,
-                angle: 0,
-                attrs: {},
-                id: '',
-                position: { x: 0, y: 0 },
-                size: { height: 0, width: 0 },
-                type: 'tm.Actor',
-                z: 0,
               },
-              {
-                hasOpenThreats: false,
-                angle: 0,
-                attrs: {},
-                id: '',
-                position: { x: 0, y: 0 },
-                size: { height: 0, width: 0 },
+            },
+            {
+              id: '00000000-0000-0000-0000-000000000004',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
                 type: 'tm.Actor',
-                z: 0,
+                name: '',
+                hasOpenThreats: false,
+                threats: [],
               },
-              {
+            },
+            {
+              id: '00000000-0000-0000-0000-000000000005',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
+                type: 'tm.Actor',
+                name: '',
                 hasOpenThreats: true,
-                angle: 0,
-                attrs: {},
-                id: '',
-                position: { x: 0, y: 0 },
-                size: { height: 0, width: 0 },
-                type: 'tm.Actor',
-                z: 0,
+                threats: [],
               },
-            ],
-          },
-          diagramType: 'STRIDE',
-          size: { width: 0, height: 0 },
-          thumbnail: '',
-          title: '',
+            },
+          ],
         },
       ],
     },

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -192,7 +192,6 @@ it('download the final model for a game', async () => {
     updatedAt: 0,
   };
 
-
   const model: ThreatDragonModelV2 = {
     version: '2.5.0',
     summary: {
@@ -213,7 +212,7 @@ it('download the final model for a game', async () => {
           cells: [
             {
               id: 'component-1',
-              shape: 'actor',          // V2 shape derived from tm.Actor
+              shape: 'actor', // V2 shape derived from tm.Actor
               zIndex: 0,
               position: { x: 0, y: 0 },
               size: { width: 0, height: 0 },
@@ -316,7 +315,6 @@ it('Download threat file', async () => {
   } as State;
 
   //Maybe I should put these jsons into a file
-
 
   const model: ThreatDragonModelV2 = {
     version: '2.5.0',

--- a/docs/docker-setup.svg
+++ b/docs/docker-setup.svg
@@ -116,7 +116,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
         <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>

--- a/docs/img/playit.svg
+++ b/docs/img/playit.svg
@@ -17,7 +17,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
         <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>

--- a/package.json
+++ b/package.json
@@ -15,8 +15,13 @@
   "packageManager": "npm@10.8.1+sha512.0e9d42e92bd2318408ed81eaff2da5f78baf23ee7d12a6eed44a6e2901d0f29d7ab715d1b918ade601f72e769a824d9a5c322383f22bbbda5dd396e79de2a077",
   "private": true,
   "overrides": {
+    "cookie": "^1.1.1",
+    "@koa/cors": "^5.0.0",
     "react": "^19.1.1",
+    "socket.io": "^4.5.0",
     "react-dom": "^19.1.1",
-    "react-is": "^19.1.1"
+    "react-is": "^19.1.1",
+    "svelte":"^4.2.19",
+    "ws":"^8.17.1"
   }
 }

--- a/packages/shared/src/game/ThreatDragonModel.ts
+++ b/packages/shared/src/game/ThreatDragonModel.ts
@@ -1,385 +1,343 @@
+
 /**
- * The threat models used by OWASP Threat Dragon
+ * Threat Dragon V2 threat model types
  *
- * This type is based on the schema at https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V1.json
+ * References:
+ * - OWASP Threat Dragon schema V2:
+ *   https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V2.json
+ * - Threat Dragon V2 data structure documentation (cells/data/threats):
+ *   https://deepwiki.com/OWASP/threat-dragon/2.1-threat-model-data-structure
+ *
+ * Notes:
+ * - V2 diagrams contain `cells` directly (no `diagramJson`).
+ * - Cells use `shape` and `zIndex` and store domain data in `data`.
+ * - Real-world V2 models may contain additional properties not strictly described by schema;
+ *   therefore most objects include `[k: string]: unknown` for forward compatibility.
  */
-export interface ThreatDragonModel {
-  /**
-   * Threat Dragon version used in the model
-   */
-  version?: string;
 
-  /**
-   * Threat model project meta-data
-   */
-  summary: {
-    /**
-     * Description of the threat model used for report outputs
-     */
-    description?: string;
-    /**
-     * A unique identifier for this main threat model object
-     */
-    id?: number;
-    /**
-     * The original creator or overall owner of the model
-     */
-    owner?: string;
-    /**
-     * Threat model title
-     */
-    title: string;
-  };
-  /**
-   * Threat model definition
-   */
-  detail: {
-    /**
-     * An array of contributors to the threat model project
-     */
-    contributors?: Contributor[];
-    /**
-     * An array of single or multiple threat data-flow diagrams
-     */
-    diagrams: Diagram[];
-  };
+export interface ThreatDragonModelV2 {
+  /** Threat Dragon version used in the model (required in V2) */
+  version: string;
+
+  /** Threat model project meta-data */
+  summary: ThreatDragonSummaryV2;
+
+  /** Threat model definition */
+  detail: ThreatDragonDetailV2;
+
+  [k: string]: unknown;
 }
 
-interface Contributor {
-  /**
-   * The name of the contributor
-   */
-  name: string;
-}
-
-interface Diagram {
-  /**
-   * The methodology used by the data-flow diagram
-   */
-  diagramType: string;
-  /**
-   * The sequence number of the diagram
-   */
-  id: number;
-  /**
-   * The size of the diagram drawing canvas
-   */
-  size: {
-    /**
-     * The height of the diagram drawing canvas
-     */
-    height: number;
-    /**
-     * The width of the diagram drawing canvas
-     */
-    width: number;
-  };
-  /**
-   * The path to the thumbnail image for the diagram
-   */
-  thumbnail: string;
-  /**
-   * The title of the data-flow diagram
-   */
+export interface ThreatDragonSummaryV2 {
+  /** Threat model title (required) */
   title: string;
-  /**
-   * Threat Dragon version used in the diagram
-   */
-  version?: string;
-  /**
-   * The data-flow diagram components
-   */
-  diagramJson: DiagramJson;
-  /**
-   * The highest diagram number in the threat model
-   */
-  diagramTop?: number;
-  /**
-   * The reviewer of the overall threat model
-   */
-  reviewer?: string;
-  /**
-   * The highest threat number in the threat model
-   */
-  threatTop?: number;
-}
 
-interface DiagramJson {
-  /**
-   * The individual diagram components
-   */
-  cells?: ThreatDragonComponent[];
-}
+  /** The original creator or overall owner of the model */
+  owner?: string;
 
-export interface ThreatDragonComponent {
-  /**
-   * The component display attributes
-   */
-  attrs: {
-    /**
-     * The component shape attributes
-     */
-    '.element-shape'?: {
-      /**
-       * The component shape display attributes
-       */
-      class?: string;
-    };
-    /**
-     * The component text
-     */
-    text?: {
-      /**
-       * The component text contents
-       */
-      text: string;
-    };
-    /**
-     * The component text attributes
-     */
-    '.element-text'?: {
-      /**
-       * The component text display attributes
-       */
-      class?: string;
-    };
-  };
-  /**
-   * The component rotation angle
-   */
-  angle?: number;
-  /**
-   * The component description
-   */
+  /** Description of the threat model used for report outputs */
   description?: string;
-  /**
-   * The component flag set if the process handles credit card payment
-   */
-  handlesCardPayment?: boolean;
-  /**
-   * The component flag set if the process is part of a retail site
-   */
-  handlesGoodsOrServices?: boolean;
-  /**
-   * The component flag set if there are open threats
-   */
-  hasOpenThreats?: boolean;
-  /**
-   * The component unique identifier (UUID)
-   */
+
+  /** A unique identifier for this main threat model object */
+  id?: number;
+
+  [k: string]: unknown;
+}
+
+export interface ThreatDragonDetailV2 {
+  /** Contributors (required in V2 schema) */
+  contributors: ContributorV2[];
+
+  /** An array of one or more diagrams (required) */
+  diagrams: DiagramV2[];
+
+  /** Counter used to generate unique diagram IDs */
+  diagramTop: number;
+
+  /** Counter used to generate unique threat IDs */
+  threatTop: number;
+
+  /** The reviewer of the overall threat model */
+  reviewer: string;
+
+  [k: string]: unknown;
+}
+
+export interface ContributorV2 {
+  name: string;
+  [k: string]: unknown;
+}
+
+export interface DiagramV2 {
+  id: number;
+  title: string;
+
+  /** Methodology type: STRIDE, LINDDUN, CIA, DIE, PLOT4ai, Generic, ... */
+  diagramType: string;
+
+  /** Diagram description (optional) */
+  description?: string;
+
+  /** Placeholder text used when description is empty (optional) */
+  placeholder?: string;
+
+  /** The path to the thumbnail image for the diagram */
+  thumbnail: string;
+
+  /** Threat Dragon version used in the diagram */
+  version: string;
+
+  /** Diagram cells (required in V2) */
+  cells: CellV2[];
+
+  [k: string]: unknown;
+}
+
+/** Common point type (used for positions and vertices) */
+export interface PointV2 {
+  x: number;
+  y: number;
+  [k: string]: unknown;
+}
+
+/**
+ * Cell definition (V2)
+ * - Nodes typically have: position + size + ports (optional)
+ * - Edges typically have: source + target + vertices (optional) + labels (optional)
+ */
+export interface CellV2 {
   id: string;
+
   /**
-   * The component flag set if the store contains logs
+   * The visual shape type, e.g.:
+   * - "process" | "actor" | "store" | "flow"
+   * - "trust-boundary-curve" | "trust-boundary-box"
+   * - "td-text-block"
    */
-  isALog?: boolean;
+  shape: string;
+
+  /** Z-index for layering elements */
+  zIndex: number;
+
+  /** Visual attributes (shape-dependent) */
+  attrs?: Record<string, unknown>;
+
+  /** Domain/business data (type/name/flags/threats) */
+  data: CellDataV2;
+
+  /** Visibility flag (commonly present in V2 files) */
+  visible?: boolean;
+
+  /** Node geometry */
+  position?: PointV2;
+  size?: { width: number; height: number; [k: string]: unknown };
+
+  /** Edge geometry (for flows and boundary curves) */
+  source?: EdgeEndV2;
+  target?: EdgeEndV2;
+  vertices?: PointV2[];
+  connector?: string;
+
+  /** Edge labels (commonly present for flows/boundaries) */
+  labels?: EdgeLabelV2[];
+
+  /** Ports (commonly present for nodes and used by edges via source.port/target.port) */
+  ports?: PortsV2;
+
+  /** Some V2 exports include width/height for edges too */
+  width?: number;
+  height?: number;
+
+  [k: string]: unknown;
+}
+
+/** Source/target endpoint for edges */
+export interface EdgeEndV2 {
   /**
-   * The component flag set if the process is a web application
+   * For edges (flows): reference to a node cell id
+   * Example: { cell: "<uuid>", port: "<uuid>" }
    */
-  isWebApplication?: boolean;
+  cell?: string;
+
+  /** Port id at the endpoint (optional) */
+  port?: string;
+
   /**
-   * The component flag set if the data flow or store is encrypted
+   * For boundary curves: coordinates can be used instead of cell reference
+   * Example: { x: 820, y: 40 }
    */
-  isEncrypted?: boolean;
-  /**
-   * The component flag set if the data store uses signatures
-   */
-  isSigned?: boolean;
-  /**
-   * The flag set if the component is a trust boundary curve or trust boundary box
-   */
-  isTrustBoundary?: boolean;
-  /**
-   * The floating labels used for boundary or data-flow
-   */
-  labels?: Label[];
-  /**
-   * The component flag set if it is not in scope
-   */
-  outOfScope?: boolean;
-  /**
-   * The component position
-   */
+  x?: number;
+  y?: number;
+
+  [k: string]: unknown;
+}
+
+/**
+ * Edge label structure as seen in V2 models.
+ * V2 labels can contain markup and positioning metadata.
+ */
+export interface EdgeLabelV2 {
+  attrs?: Record<string, unknown>;
+  markup?: Array<{ tagName: string; selector: string; [k: string]: unknown }>;
   position?: {
-    /**
-     * The component horizontal position
-     */
-    x: number;
-    /**
-     * The component vertical position
-     */
-    y: number;
+    distance?: number;
+    args?: Record<string, unknown>;
     [k: string]: unknown;
   };
-  /**
-   * The component's level of privilege/permissions
-   */
-  privilegeLevel?: string;
-  /**
-   * The component description if out of scope
-   */
-  reasonOutOfScope?: string;
-  /**
-   * The component size
-   */
-  size: {
-    /**
-     * The component height
-     */
-    height: number;
-    /**
-     * The component width
-     */
-    width: number;
-  };
-  /**
-   * The component curve type, for data flows and boundaries
-   */
-  smooth?: boolean;
-  /**
-   * The component curve source
-   */
-  source?: {
-    /**
-     * The data-flow source component
-     */
-    id?: string;
-    /**
-     * The boundary horizontal curve source
-     */
-    x?: number;
-    /**
-     * The boundary vertical curve source
-     */
-    y?: number;
-  };
-  /**
-   * The component flag set if store contains credentials/PII
-   */
-  storesCredentials?: boolean;
-  /**
-   * The component flag set if store is part of a retail web application
-   */
-  storesInventory?: boolean;
-  /**
-   * The component curve target
-   */
-  target?: {
-    /**
-     * The data-flow target component
-     */
-    id?: string;
-    /**
-     * The boundary horizontal curve target
-     */
-    x?: number;
-    /**
-     * The boundary vertical curve target
-     */
-    y?: number;
-  };
-  /**
-   * The threats associated with the component
-   */
-  threats?: ThreatDragonThreat[];
-  type: CellType;
-  /**
-   * The boundary or data-flow curve points
-   */
-  vertices?: {
-    /**
-     * The horizontal value of the curve point
-     */
-    x: number;
-    /**
-     * The vertical value of the curve point
-     */
-    y: number;
-  };
-  z: number;
+  [k: string]: unknown;
 }
 
-interface Label {
-  /**
-   * The label position
-   */
-  position: number;
-  /**
-   * The label text attributes
-   */
-  attrs: {
-    /**
-     * The text attributes
-     */
-    text: {
-      /**
-       * The text size
-       */
-      'font-size': string;
-      /**
-       * The text weight
-       */
-      'font-weight': string;
-      /**
-       * The text content
-       */
-      text: string;
-    };
-  };
+/** Ports definition used by V2 cells (nodes) */
+export interface PortsV2 {
+  groups?: Record<
+    string,
+    {
+      position?: string;
+      attrs?: Record<string, unknown>;
+      [k: string]: unknown;
+    }
+  >;
+
+  items?: Array<{
+    group: string;
+    id: string;
+    [k: string]: unknown;
+  }>;
+
+  [k: string]: unknown;
 }
 
-type CellType =
-  | 'tm.Process'
-  | 'tm.Store'
-  | 'tm.Actor'
-  | 'tm.Flow'
-  | 'tm.Boundary';
-
-export interface ThreatDragonThreat {
-  /**
-   * The threat description
-   */
-  description: string;
-  /**
-   * The threat mitigation
-   */
-  mitigation: string;
-  /**
-   * The threat methodology type
-   */
-  modelType?: string;
-  /**
-   * The unique number for the threat
-   */
-  number?: number;
-  /**
-   * The custom score/risk for the threat
-   */
-  score?: string;
-  /**
-   * The threat severity as High, Medium or Low
-   */
-  severity: string;
-  /**
-   * The threat status as NA, Open or Mitigated
-   */
-  status: Status;
-  /**
-   * The threat ID as a UUID
-   */
+/**
+ * Threats in V2:
+ * - In practice, threats are usually stored under cell.data.threats[]
+ * - Schema variants may contain threatId or id; we allow both.
+ */
+export interface ThreatV2 {
+  id?: string;
   threatId?: string;
-  /**
-   * The threat title
-   */
+
+  number?: number;
+
   title: string;
-  /**
-   * The threat type, selection according to modelType
-   */
+  status: "NA" | "Open" | "Mitigated" | string;
+
+  severity: "Low" | "Medium" | "High" | "Critical" | string;
+
+  /** Category depends on methodology (e.g., STRIDE categories, CIA categories, etc.) */
   type: string;
 
-  // our custom properties
-  owner?: string;
-  id?: string;
-  game?: string;
+  description: string;
+  mitigation: string;
+
+  modelType?: string;
+  score?: string;
+
+  /** sometimes present in exported models */
+  new?: boolean;
+
+  [k: string]: unknown;
 }
 
-type Status = 'NA' | 'Open' | 'Mitigated';
+/** Base properties common across V2 cell data types */
+export interface BaseCellDataV2 {
+  /** Type identifier, e.g. tm.Process, tm.Actor, tm.Store, tm.Flow, tm.Boundary, tm.Text, tm.BoundaryBox */
+  type: string;
+
+  /** Display name */
+  name: string;
+
+  /** Optional description */
+  description?: string;
+
+  /** Out-of-scope flags */
+  outOfScope?: boolean;
+  reasonOutOfScope?: string;
+
+  /** Flag whether there are open threats */
+  hasOpenThreats: boolean;
+
+  /** For boundaries */
+  isTrustBoundary?: boolean;
+
+  /** Associated threats */
+  threats?: ThreatV2[];
+
+  [k: string]: unknown;
+}
+
+/**
+ * Discriminated union for common V2 cell data types.
+ * Includes types seen in real models (e.g., tm.BoundaryBox, tm.Text).
+ */
+export type CellDataV2 =
+  | ProcessDataV2
+  | StoreDataV2
+  | ActorDataV2
+  | FlowDataV2
+  | BoundaryDataV2
+  | BoundaryBoxDataV2
+  | TextBlockDataV2
+  | (BaseCellDataV2 & { type: string }); // fallback for forward compatibility
+
+export interface ProcessDataV2 extends BaseCellDataV2 {
+  type: "tm.Process";
+  handlesCardPayment?: boolean;
+  handlesGoodsOrServices?: boolean;
+  isWebApplication?: boolean;
+  privilegeLevel?: string;
+
+  /** present in some models */
+  threatFrequency?: Record<string, number>;
+
+  [k: string]: unknown;
+}
+
+export interface StoreDataV2 extends BaseCellDataV2 {
+  type: "tm.Store";
+  isALog?: boolean;
+  isEncrypted?: boolean;
+  isSigned?: boolean;
+  storesCredentials?: boolean;
+  storesInventory?: boolean;
+
+  [k: string]: unknown;
+}
+
+export interface ActorDataV2 extends BaseCellDataV2 {
+  type: "tm.Actor";
+  providesAuthentication?: boolean;
+
+  [k: string]: unknown;
+}
+
+export interface FlowDataV2 extends BaseCellDataV2 {
+  type: "tm.Flow";
+  isBidirectional?: boolean;
+  isEncrypted?: boolean;
+  isPublicNetwork?: boolean;
+  protocol?: string;
+
+  [k: string]: unknown;
+}
+
+export interface BoundaryDataV2 extends BaseCellDataV2 {
+  type: "tm.Boundary";
+  isTrustBoundary: boolean;
+
+  [k: string]: unknown;
+}
+
+/** Appears in some V2 models for trust boundary boxes */
+export interface BoundaryBoxDataV2 extends BaseCellDataV2 {
+  type: "tm.BoundaryBox";
+  isTrustBoundary: boolean;
+
+  [k: string]: unknown;
+}
+
+/** Appears in some V2 models for free text blocks */
+export interface TextBlockDataV2 extends BaseCellDataV2 {
+  type: "tm.Text";
+  [k: string]: unknown;
+}
+

--- a/packages/shared/src/game/ThreatDragonModel.ts
+++ b/packages/shared/src/game/ThreatDragonModel.ts
@@ -1,4 +1,3 @@
-
 /**
  * Threat Dragon V2 threat model types
  *
@@ -219,9 +218,9 @@ export interface ThreatV2 {
   number?: number;
 
   title: string;
-  status: "NA" | "Open" | "Mitigated" | string;
+  status: 'NA' | 'Open' | 'Mitigated' | string;
 
-  severity: "Low" | "Medium" | "High" | "Critical" | string;
+  severity: 'Low' | 'Medium' | 'High' | 'Critical' | string;
 
   /** Category depends on methodology (e.g., STRIDE categories, CIA categories, etc.) */
   type: string;
@@ -280,7 +279,7 @@ export type CellDataV2 =
   | (BaseCellDataV2 & { type: string }); // fallback for forward compatibility
 
 export interface ProcessDataV2 extends BaseCellDataV2 {
-  type: "tm.Process";
+  type: 'tm.Process';
   handlesCardPayment?: boolean;
   handlesGoodsOrServices?: boolean;
   isWebApplication?: boolean;
@@ -293,7 +292,7 @@ export interface ProcessDataV2 extends BaseCellDataV2 {
 }
 
 export interface StoreDataV2 extends BaseCellDataV2 {
-  type: "tm.Store";
+  type: 'tm.Store';
   isALog?: boolean;
   isEncrypted?: boolean;
   isSigned?: boolean;
@@ -304,14 +303,14 @@ export interface StoreDataV2 extends BaseCellDataV2 {
 }
 
 export interface ActorDataV2 extends BaseCellDataV2 {
-  type: "tm.Actor";
+  type: 'tm.Actor';
   providesAuthentication?: boolean;
 
   [k: string]: unknown;
 }
 
 export interface FlowDataV2 extends BaseCellDataV2 {
-  type: "tm.Flow";
+  type: 'tm.Flow';
   isBidirectional?: boolean;
   isEncrypted?: boolean;
   isPublicNetwork?: boolean;
@@ -321,7 +320,7 @@ export interface FlowDataV2 extends BaseCellDataV2 {
 }
 
 export interface BoundaryDataV2 extends BaseCellDataV2 {
-  type: "tm.Boundary";
+  type: 'tm.Boundary';
   isTrustBoundary: boolean;
 
   [k: string]: unknown;
@@ -329,7 +328,7 @@ export interface BoundaryDataV2 extends BaseCellDataV2 {
 
 /** Appears in some V2 models for trust boundary boxes */
 export interface BoundaryBoxDataV2 extends BaseCellDataV2 {
-  type: "tm.BoundaryBox";
+  type: 'tm.BoundaryBox';
   isTrustBoundary: boolean;
 
   [k: string]: unknown;
@@ -337,7 +336,6 @@ export interface BoundaryBoxDataV2 extends BaseCellDataV2 {
 
 /** Appears in some V2 models for free text blocks */
 export interface TextBlockDataV2 extends BaseCellDataV2 {
-  type: "tm.Text";
+  type: 'tm.Text';
   [k: string]: unknown;
 }
-

--- a/packages/shared/src/game/ThreatDragonModel.ts
+++ b/packages/shared/src/game/ThreatDragonModel.ts
@@ -138,7 +138,7 @@ export interface CellV2 {
   connector?: string;
 
   /** Edge labels (commonly present for flows/boundaries) */
-  labels?: EdgeLabelV2[];
+  labels?: string[];
 
   /** Ports (commonly present for nodes and used by edges via source.port/target.port) */
   ports?: PortsV2;

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { ThreatDragonModel } from '../game/ThreatDragonModel';
+import type {ThreatDragonModelV2} from '../game/ThreatDragonModel';
 
 export enum ModelType {
   THREAT_DRAGON = 'Threat Dragon',
@@ -13,7 +13,9 @@ export const MIN_NUMBER_PLAYERS = 2;
 export const MAX_NUMBER_PLAYERS = 9;
 export const DEFAULT_TURN_DURATION = 300;
 
-export const DEFAULT_MODEL: ThreatDragonModel = {
+
+export const DEFAULT_MODEL: ThreatDragonModelV2 = {
+  version: '2.5.0',
   summary: {
     title: 'Threat Modelling',
   },
@@ -21,47 +23,44 @@ export const DEFAULT_MODEL: ThreatDragonModel = {
     contributors: [],
     diagrams: [
       {
-        title: 'Threat Modelling',
-        thumbnail: '',
-        diagramType: 'STRIDE',
         id: 0,
-        diagramJson: {
-          cells: [
-            {
-              type: 'tm.Actor',
-              size: {
-                width: 160,
-                height: 80,
-              },
-              position: {
-                x: 50,
-                y: 50,
-              },
-              angle: 0,
-              id: '90cdcc2d-21ab-443d-ae95-f97a798429e7',
-              z: 1,
-              hasOpenThreats: false,
-              attrs: {
-                '.element-shape': {
-                  class: 'element-shape hasNoOpenThreats isInScope',
-                },
-                text: {
-                  text: 'Application',
-                },
-                '.element-text': {
-                  class: 'element-text hasNoOpenThreats isInScope',
-                },
-              },
+        title: 'Threat Modelling',
+        diagramType: 'STRIDE',
+        thumbnail: '',
+        version: '2.5.0',
+        cells: [
+          {
+            id: '90cdcc2d-21ab-443d-ae95-f97a798429e7',
+            shape: 'actor',
+            zIndex: 1,
+            visible: true,
+
+            position: { x: 50, y: 50 },
+            size: { width: 160, height: 80 },
+            attrs: {
+              text: { text: 'Application' },
+              body: { stroke: '#333333', strokeWidth: 1.5, strokeDasharray: null },
             },
-          ],
-        },
-        size: {
-          height: 590,
-          width: 790,
-        },
+
+            data: {
+              type: 'tm.Actor',
+              name: 'Application',
+              description: '',
+              outOfScope: false,
+              reasonOutOfScope: '',
+              hasOpenThreats: false,
+              providesAuthentication: false,
+              threats: [],
+            },
+          },
+        ],
       },
     ],
+    diagramTop: 1,
+    threatTop: 0,
+    reviewer: '',
   },
 };
+
 
 export const SPECTATOR = 'spectator';

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type {ThreatDragonModelV2} from '../game/ThreatDragonModel';
+import type { ThreatDragonModelV2 } from '../game/ThreatDragonModel';
 
 export enum ModelType {
   THREAT_DRAGON = 'Threat Dragon',
@@ -12,7 +12,6 @@ export const CARD_LIMIT = 26;
 export const MIN_NUMBER_PLAYERS = 2;
 export const MAX_NUMBER_PLAYERS = 9;
 export const DEFAULT_TURN_DURATION = 300;
-
 
 export const DEFAULT_MODEL: ThreatDragonModelV2 = {
   version: '2.5.0',
@@ -39,7 +38,11 @@ export const DEFAULT_MODEL: ThreatDragonModelV2 = {
             size: { width: 160, height: 80 },
             attrs: {
               text: { text: 'Application' },
-              body: { stroke: '#333333', strokeWidth: 1.5, strokeDasharray: null },
+              body: {
+                stroke: '#333333',
+                strokeWidth: 1.5,
+                strokeDasharray: null,
+              },
             },
 
             data: {
@@ -61,6 +64,5 @@ export const DEFAULT_MODEL: ThreatDragonModelV2 = {
     reviewer: '',
   },
 };
-
 
 export const SPECTATOR = 'spectator';

--- a/packages/shared/src/utils/utils.test.ts
+++ b/packages/shared/src/utils/utils.test.ts
@@ -15,6 +15,7 @@ import {
 } from './utils';
 
 import type { GameState } from '../game/gameState';
+import type { CellV2 } from '../game/ThreatDragonModel';
 
 const baseG: GameState = {
   dealt: [],
@@ -102,40 +103,47 @@ it('creates player array correctly', () => {
 
 it('makes correct component name', () => {
   expect(getComponentName(undefined)).toBe('');
-  expect(
-    getComponentName({
+
+  const actorCell: CellV2 = {
+    id: 'some-id',
+    shape: 'actor',
+    zIndex: 0,
+    attrs: {
+      text: {
+        text: 'Bar',
+      },
+    },
+    data: {
       type: 'tm.Actor',
-      attrs: {
-        text: {
-          text: 'Bar',
+      name: '',
+      hasOpenThreats: false,
+    },
+  };
+
+  expect(getComponentName(actorCell)).toBe('Actor: Bar');
+
+  const flowCell: CellV2 = {
+    id: 'some-id',
+    shape: 'flow',
+    zIndex: 0,
+    attrs: {},
+    labels: [
+      {
+        attrs: {
+          labelText: {
+            text: 'Bar',
+          },
         },
       },
-      id: 'some-id',
-      size: { width: 0, height: 0 },
-      z: 0,
-    }),
-  ).toBe('Actor: Bar');
-  expect(
-    getComponentName({
+    ],
+    data: {
       type: 'tm.Flow',
-      labels: [
-        {
-          attrs: {
-            text: {
-              text: 'Bar',
-              'font-size': '12pt',
-              'font-weight': 'bold',
-            },
-          },
-          position: 0,
-        },
-      ],
-      attrs: {},
-      id: 'some-id',
-      size: { width: 0, height: 0 },
-      z: 0,
-    }),
-  ).toBe('Flow: Bar');
+      name: '',
+      hasOpenThreats: false,
+    },
+  };
+
+  expect(getComponentName(flowCell)).toBe('Flow: Bar');
 });
 
 it('produces valid moves', () => {

--- a/packages/shared/src/utils/utils.ts
+++ b/packages/shared/src/utils/utils.ts
@@ -1,8 +1,8 @@
-import type {PlayerID} from 'boardgame.io';
-import type {GameState} from '../game/gameState';
-import type {Card, Suit} from './cardDefinitions';
-import {ModelType} from './constants';
-import {CellV2} from "../game/ThreatDragonModel";
+import type { PlayerID } from 'boardgame.io';
+import type { GameState } from '../game/gameState';
+import type { Card, Suit } from './cardDefinitions';
+import { ModelType } from './constants';
+import { CellV2 } from '../game/ThreatDragonModel';
 
 export function getDealtCard(G: GameState): string {
   if (G.dealt.length > 0 && G.dealtBy) {
@@ -120,7 +120,6 @@ export function isModelType(value: string): value is ModelType {
   return Object.values<string>(ModelType).includes(value);
 }
 
-
 function getV2CellType(cell: CellV2): string {
   return typeof cell.data?.type === 'string' ? cell.data.type : '';
 }
@@ -148,7 +147,8 @@ function getV2FlowLabel(cell: CellV2): string {
   const attrs = labels[0]?.attrs;
   if (!attrs || typeof attrs !== 'object') return '';
 
-  const labelText = (attrs as { labelText?: { text?: unknown } }).labelText?.text;
+  const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
+    ?.text;
   if (typeof labelText === 'string' && labelText.trim()) return labelText;
 
   const label = (attrs as { label?: { text?: unknown } }).label?.text;

--- a/packages/shared/src/utils/utils.ts
+++ b/packages/shared/src/utils/utils.ts
@@ -144,15 +144,8 @@ function getV2FlowLabel(cell: CellV2): string {
   const labels = cell.labels ?? [];
   if (!Array.isArray(labels) || labels.length === 0) return '';
 
-  const attrs = labels[0]?.attrs;
-  if (!attrs || typeof attrs !== 'object') return '';
-
-  const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
-    ?.text;
-  if (typeof labelText === 'string' && labelText.trim()) return labelText;
-
-  const label = (attrs as { label?: { text?: unknown } }).label?.text;
-  if (typeof label === 'string' && label.trim()) return label;
+  const text = labels[0];
+  if (typeof text === 'string' && text.trim()) return text;
 
   return '';
 }


### PR DESCRIPTION
Since some time Threat Dragon switched to a [new model schema](https://github.com/OWASP/threat-dragon/blob/main/td.vue/src/assets/schema/threat-dragon-v2.schema.json). The original function of EoP to import Threat Dragon models is deprecated and useless since.

- We adapted the whole EoP data model and import function from v1 to v2, so that current Threat Dragon Models can be imported and used interactively again ingame.

- Also we pinned a couple of dependencies to clear the project from all CVEs, to make it safer to use. This works fine, however, the project will break eventually when new CVEs emerge and get only fixed in dependencies that are not compatible with the unmaintained underlying [boardgame.io](https://boardgame.io/) package.

- We also fixed 3 warnings about unsafe usage of HTTP links.

Looking forward for seeing these changes to get merged in the TNG repo. Thank you for maintaining this game. 