### PR TITLE
Fix file upload restriction bypass via Content-Type manipulation

### DIFF
--- a/.changeset/sec-file-upload-validation.md
+++ b/.changeset/sec-file-upload-validation.md
@@ -1,0 +1,15 @@
+---
+"@eop/server": patch
+"@eop/client": patch
+---
+
+Fix file upload restriction bypass via Content-Type manipulation (CWE-434).
+Image uploads to POST /api/game/create are now validated server-side against
+a strict allowlist (PNG, JPEG, GIF, WebP, SVG) and the actual file content is
+verified via magic-byte sniffing, so an attacker can no longer upload
+arbitrary file types (e.g. PHP, HTML) by spoofing the multipart Content-Type
+header. The stored file extension is now derived from the server allowlist
+rather than the client-supplied filename. Additionally, X-Content-Type-Options:
+nosniff, X-Frame-Options, and a strict Content-Security-Policy are now set on
+both the API (Koa) and the static client (nginx) responses as defense-in-depth
+against stored XSS via content-type confusion.

--- a/apps/client/nginx/etc/nginx/conf.d/default.conf
+++ b/apps/client/nginx/etc/nginx/conf.d/default.conf
@@ -2,6 +2,12 @@ server {
 	listen       8080;
     server_name  localhost;
 
+    # Defense-in-depth security headers for the static client. API responses
+    # are proxied to the Koa server, which sets these headers itself.
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'" always;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html;

--- a/apps/server/src/endpoints.ts
+++ b/apps/server/src/endpoints.ts
@@ -1,4 +1,4 @@
-import { rename } from 'node:fs/promises';
+import { readFile, rename } from 'node:fs/promises';
 
 import {
   DEFAULT_MODEL,
@@ -6,7 +6,6 @@ import {
   GameMode,
   gameName,
   GameState,
-  getImageExtension,
   getSuitDisplayName,
   isSuit,
   logEvent,
@@ -22,6 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { INTERNAL_API_PORT } from './config';
 import { getDbImagesFolder } from './filesystem';
+import { validateImageFile } from './imageFileType';
 
 import type { Server, State } from 'boardgame.io';
 import type { IMiddleware } from 'koa-router';
@@ -100,25 +100,22 @@ export const createGame =
             throw Error('A single image needs to be provided');
           }
 
-          if (!ctx.request.files.model.originalFilename) {
+          const file = ctx.request.files.model;
+          const declaredMimeType = file.mimetype;
+          if (!declaredMimeType) {
+            throw Error('No mime type specified for the provided image');
+          }
+          const originalFilename = file.originalFilename;
+          if (!originalFilename) {
             throw Error('No name specified for the provided image');
           }
 
-          if (!ctx.request.files.model.mimetype) {
-            throw Error('No mime type specified for the provided image');
-          }
-
-          const extension = getImageExtension(
-            ctx.request.files.model.originalFilename,
+          const fileBuffer = await readFile(file.filepath);
+          const { extension } = validateImageFile(
+            declaredMimeType,
+            originalFilename,
+            fileBuffer,
           );
-          if (
-            !(
-              /image\/[a-z+]+$/i.test(ctx.request.files.model.mimetype) &&
-              extension
-            )
-          ) {
-            throw Error('Filetype not supported');
-          }
 
           await rename(
             ctx.request.files.model.filepath,

--- a/apps/server/src/imageFileType.test.ts
+++ b/apps/server/src/imageFileType.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALLOWED_IMAGE_TYPES,
+  looksLikeSvg,
+  validateImageFile,
+} from './imageFileType';
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+
+const GIF89A_SIGNATURE = Buffer.from('GIF89a');
+
+const WEBP_SIGNATURE = Buffer.from('RIFF\x00\x00\x00\x00WEBP', 'binary');
+
+const MINIMAL_PNG = Buffer.concat([
+  PNG_SIGNATURE,
+  Buffer.from(
+    // IHDR chunk (13 bytes data) + IEND
+    '\x00\x00\x00\x0dIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xff\xff?\x00\x05\xfe\x02\xfe\xa3U\xe7\xe6\x00\x00\x00\x00IEND\xaeB`\x82',
+  ),
+]);
+
+describe('validateImageFile', () => {
+  describe('valid uploads', () => {
+    it('accepts a real PNG with matching Content-Type and .png extension', () => {
+      const result = validateImageFile('image/png', 'diagram.png', MINIMAL_PNG);
+      expect(result).toEqual({
+        mimeType: 'image/png',
+        extension: 'png',
+        isSvg: false,
+      });
+    });
+
+    it('accepts a PNG with a mismatched (but absent) extension', () => {
+      const result = validateImageFile('image/png', 'noext', MINIMAL_PNG);
+      expect(result.extension).toBe('png');
+    });
+
+    it('accepts a JPEG with .jpg extension', () => {
+      const result = validateImageFile(
+        'image/jpeg',
+        'photo.jpg',
+        JPEG_SIGNATURE,
+      );
+      expect(result.extension).toBe('jpg');
+    });
+
+    it('accepts a GIF with .gif extension', () => {
+      const result = validateImageFile(
+        'image/gif',
+        'anim.gif',
+        GIF89A_SIGNATURE,
+      );
+      expect(result.extension).toBe('gif');
+    });
+
+    it('accepts a WebP with .webp extension', () => {
+      const result = validateImageFile(
+        'image/webp',
+        'pic.webp',
+        WEBP_SIGNATURE,
+      );
+      expect(result.extension).toBe('webp');
+    });
+
+    it('accepts an SVG by extension without checking magic bytes', () => {
+      const svg = Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
+      );
+      const result = validateImageFile('image/svg+xml', 'drawing.svg', svg);
+      expect(result).toEqual({
+        mimeType: 'image/svg+xml',
+        extension: 'svg',
+        isSvg: true,
+      });
+    });
+
+    it('accepts an SVG whose declared MIME is image/svg+xml even when content is short', () => {
+      const result = validateImageFile(
+        'image/svg+xml',
+        'x.svg',
+        Buffer.from('<svg/>'),
+      );
+      expect(result.isSvg).toBe(true);
+    });
+  });
+
+  describe('rejected uploads', () => {
+    it('rejects a .php file claiming Content-Type: image/png with PHP body', () => {
+      const php = Buffer.from('<?php echo "Hello, World!"; ?>');
+      expect(() => validateImageFile('image/png', 'file.php', php)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects an HTML file claiming Content-Type: image/html', () => {
+      const html = Buffer.from('<html><script>alert(1)</script></html>');
+      // image/html is not in the allowlist
+      expect(() => validateImageFile('image/html', 'x.html', html)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects a PHP body claiming Content-Type: image/png but no extension', () => {
+      const php = Buffer.from('<?php echo "Hello, World!"; ?>');
+      expect(() => validateImageFile('image/png', 'no-extension', php)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects a .php extension even when magic bytes are absent', () => {
+      expect(() =>
+        validateImageFile('image/png', 'shell.php', MINIMAL_PNG),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects a PHP file claiming image/png with .png filename', () => {
+      // This is the core of the report: Content-Type spoofed to image/png
+      // and extension .png, but the actual content is PHP.
+      const php = Buffer.from('<?php system($_GET["c"]); ?>');
+      expect(() => validateImageFile('image/png', 'evil.png', php)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects a PHP file claiming image/jpeg with .jpg filename', () => {
+      const php = Buffer.from('<?php echo 1; ?>');
+      expect(() => validateImageFile('image/jpeg', 'evil.jpg', php)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects an SVG content payload claiming image/png with .png extension', () => {
+      // SVG has no PNG magic bytes, so magic-byte sniffing rejects it even
+      // though the MIME and extension both claim PNG. (SVG uploads must use
+      // the image/svg+xml MIME type, which is then sanitized downstream.)
+      const svg = Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      );
+      expect(() => validateImageFile('image/png', 'evil.png', svg)).toThrow(
+        'Filetype not supported',
+      );
+    });
+
+    it('rejects a .html extension with image/png Content-Type', () => {
+      expect(() =>
+        validateImageFile('image/png', 'evil.html', MINIMAL_PNG),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects an arbitrary executable extension (.sh) with image/png', () => {
+      expect(() =>
+        validateImageFile('image/png', 'evil.sh', MINIMAL_PNG),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects an unknown MIME type', () => {
+      expect(() =>
+        validateImageFile('application/x-php', 'x.php', MINIMAL_PNG),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects text/html MIME', () => {
+      expect(() =>
+        validateImageFile('text/html', 'x.html', Buffer.from('<html/>')),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects a PNG declared as image/jpeg (cross-type mismatch)', () => {
+      expect(() =>
+        validateImageFile('image/jpeg', 'x.jpg', MINIMAL_PNG),
+      ).toThrow('Filetype not supported');
+    });
+
+    it('rejects an empty buffer claiming image/png', () => {
+      expect(() =>
+        validateImageFile('image/png', 'x.png', Buffer.alloc(0)),
+      ).toThrow('Filetype not supported');
+    });
+  });
+});
+
+describe('ALLOWED_IMAGE_TYPES', () => {
+  it('contains the expected entries', () => {
+    expect(ALLOWED_IMAGE_TYPES).toEqual({
+      'image/png': 'png',
+      'image/jpeg': 'jpg',
+      'image/gif': 'gif',
+      'image/webp': 'webp',
+      'image/svg+xml': 'svg',
+    });
+  });
+});
+
+describe('looksLikeSvg', () => {
+  it('detects an SVG by <svg tag', () => {
+    expect(
+      looksLikeSvg(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"/>')),
+    ).toBe(true);
+  });
+
+  it('detects an SVG by xml declaration', () => {
+    expect(
+      looksLikeSvg(
+        Buffer.from(
+          '<?xml version="1.0"?>\n<svg xmlns="http://www.w3.org/2000/svg"/>',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a PNG buffer', () => {
+    expect(looksLikeSvg(MINIMAL_PNG)).toBe(false);
+  });
+
+  it('returns false for arbitrary text', () => {
+    expect(looksLikeSvg(Buffer.from('hello world'))).toBe(false);
+  });
+});

--- a/apps/server/src/imageFileType.ts
+++ b/apps/server/src/imageFileType.ts
@@ -1,0 +1,165 @@
+/**
+ * Server-side validation of uploaded image files.
+ *
+ * The previous implementation trusted the client-supplied `Content-Type`
+ * header and the filename extension independently, which allowed an attacker
+ * to upload arbitrary file types (e.g. `.php`, `.html`) by claiming an
+ * `image/*` MIME type. This module enforces a strict allowlist and verifies
+ * the actual file content via magic-byte sniffing, so the client-supplied
+ * MIME type and extension can no longer bypass validation on their own.
+ */
+
+/**
+ * Allowlist of MIME types that may be uploaded as image models, mapped to the
+ * canonical extension the server uses when persisting the file. The stored
+ * extension is always derived from this map, never from the client-supplied
+ * filename, so attackers cannot control the on-disk extension.
+ */
+export const ALLOWED_IMAGE_TYPES: Readonly<Record<string, string>> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+};
+
+export type ImageTypeResult = {
+  /** Canonical MIME type, determined from the allowlist. */
+  readonly mimeType: string;
+  /** Canonical file extension, derived from the allowlist. */
+  readonly extension: string;
+  /** Whether the file was detected as SVG (by extension or content). */
+  readonly isSvg: boolean;
+};
+
+/**
+ * Magic-byte signatures for the allowed raster formats. SVG is detected
+ * separately by content sniffing (see {@link looksLikeSvg}).
+ */
+const MAGIC_BYTES: ReadonlyArray<{
+  readonly mimeType: string;
+  readonly match: (buf: Buffer) => boolean;
+}> = [
+  {
+    mimeType: 'image/png',
+    match: (b) =>
+      b.length >= 8 &&
+      b[0] === 0x89 &&
+      b[1] === 0x50 &&
+      b[2] === 0x4e &&
+      b[3] === 0x47 &&
+      b[4] === 0x0d &&
+      b[5] === 0x0a &&
+      b[6] === 0x1a &&
+      b[7] === 0x0a,
+  },
+  {
+    mimeType: 'image/jpeg',
+    match: (b) =>
+      b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff,
+  },
+  {
+    mimeType: 'image/gif',
+    match: (b) =>
+      b.length >= 6 &&
+      (b.subarray(0, 6).equals(Buffer.from('GIF87a')) ||
+        b.subarray(0, 6).equals(Buffer.from('GIF89a'))),
+  },
+  {
+    // RIFF....WEBP
+    mimeType: 'image/webp',
+    match: (b) =>
+      b.length >= 12 &&
+      b.subarray(0, 4).equals(Buffer.from('RIFF')) &&
+      b.subarray(8, 12).equals(Buffer.from('WEBP')),
+  },
+];
+
+const SVG_CONTENT_HINTS: ReadonlyArray<RegExp> = [
+  /<\?xml[^>]*\bsvg\b/i,
+  /<svg\b/i,
+  /\bxmlns\s*=\s*["']https?:\/\/www\.w3\.org\/2000\/svg["']/i,
+];
+
+/**
+ * Detects whether a buffer is an SVG, either by extension hint or by content
+ * sniffing. This catches payloads that were renamed to a non-SVG extension to
+ * bypass extension-based checks.
+ */
+export const looksLikeSvg = (buffer: Buffer): boolean => {
+  const head = buffer.subarray(0, 1024).toString('utf8');
+  return SVG_CONTENT_HINTS.some((hint) => hint.test(head));
+};
+
+const sniffMagicBytes = (buffer: Buffer): string | undefined => {
+  for (const { mimeType, match } of MAGIC_BYTES) {
+    if (match(buffer)) {
+      return mimeType;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Validates an uploaded image file against the allowlist, cross-checking the
+ * client-supplied MIME type, the client-supplied filename extension, and the
+ * actual file content (magic bytes for raster formats).
+ *
+ * SVG is accepted when the declared MIME type is `image/svg+xml`; it has no
+ * reliable magic bytes, so content sniffing is intentionally not performed
+ * here. A separate sanitization step is responsible for neutralizing active
+ * content in SVG uploads.
+ *
+ * @param declaredMimeType The MIME type from the multipart `Content-Type`
+ *   header (client-controlled).
+ * @param originalFilename The original filename from the multipart part
+ *   (client-controlled).
+ * @param fileBuffer The uploaded file content. Only the first few KB are read.
+ * @returns The canonical MIME type, extension, and SVG flag on success.
+ * @throws Error if the file is not a supported image type, the declared MIME
+ *   does not match the allowlist, the extension does not match the MIME, or the
+ *   magic bytes do not match the claimed type.
+ */
+export const validateImageFile = (
+  declaredMimeType: string,
+  originalFilename: string,
+  fileBuffer: Buffer,
+): ImageTypeResult => {
+  const canonicalExtension = ALLOWED_IMAGE_TYPES[declaredMimeType];
+  if (canonicalExtension === undefined) {
+    throw new Error('Filetype not supported');
+  }
+
+  const clientExtension = extractExtension(originalFilename);
+  if (clientExtension !== undefined && clientExtension !== canonicalExtension) {
+    // The extension does not have to match the MIME, but if one is provided it
+    // must not contradict the allowlist (e.g. `Content-Type: image/png` with
+    // `evil.php` is rejected).
+    throw new Error('Filetype not supported');
+  }
+
+  if (canonicalExtension === 'svg') {
+    // SVG has no reliable magic bytes; rely on sanitization downstream.
+    return { mimeType: 'image/svg+xml', extension: 'svg', isSvg: true };
+  }
+
+  const sniffed = sniffMagicBytes(fileBuffer);
+  if (sniffed === undefined) {
+    throw new Error('Filetype not supported');
+  }
+  if (sniffed !== declaredMimeType) {
+    // E.g. a PHP file claiming `Content-Type: image/png`.
+    throw new Error('Filetype not supported');
+  }
+
+  return {
+    mimeType: sniffed,
+    extension: canonicalExtension,
+    isSvg: false,
+  };
+};
+
+const extractExtension = (filename: string): string | undefined => {
+  const match = filename.match(/\.([A-Za-z0-9+]+)$/);
+  return match?.[1]?.toLowerCase();
+};

--- a/apps/server/src/imageFileType.ts
+++ b/apps/server/src/imageFileType.ts
@@ -131,7 +131,12 @@ export const validateImageFile = (
   }
 
   const clientExtension = extractExtension(originalFilename);
-  if (clientExtension !== undefined && clientExtension !== canonicalExtension) {
+  const normalizedClientExtension =
+    clientExtension === 'jpeg' ? 'jpg' : clientExtension;
+  if (
+    normalizedClientExtension !== undefined &&
+    normalizedClientExtension !== canonicalExtension
+  ) {
     // The extension does not have to match the MIME, but if one is provided it
     // must not contradict the allowlist (e.g. `Content-Type: image/png` with
     // `evil.php` is rejected).

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -493,6 +493,107 @@ it('Download threat file', async () => {
 `);
 });
 
+describe('image upload validation (CWE-434)', () => {
+  const names = ['P1', 'P2', 'P3'];
+
+  const minimalPng = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.from(
+      '\x00\x00\x00\x0dIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xff\xff?\x00\x05\xfe\x02\xfe\xa3U\xe7\xe6\x00\x00\x00\x00IEND\xaeB`\x82',
+    ),
+  ]);
+
+  const createWithImage = (
+    body: Buffer,
+    filename: string,
+    contentType: string,
+  ) =>
+    request(publicApiServer.callback())
+      .post('/game/create')
+      .field('startSuit', 'A')
+      .field('gameMode', 'Elevation of Privilege')
+      .field('modelType', ModelType.IMAGE)
+      .field('turnDuration', '5')
+      .field('names[]', names)
+      .attach('model', body, { filename, contentType });
+
+  it('rejects a PHP payload claiming Content-Type image/png', async () => {
+    const response = await createWithImage(
+      Buffer.from('<?php echo "Hello, World!"; ?>'),
+      'file.php',
+      'image/png',
+    );
+    expect(response.status).toBe(500);
+    expect((response.body as { game?: string }).game).toBeUndefined();
+  });
+
+  it('rejects a PHP payload with .png extension and image/png Content-Type', async () => {
+    const response = await createWithImage(
+      Buffer.from('<?php system($_GET["c"]); ?>'),
+      'evil.png',
+      'image/png',
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('rejects an HTML payload claiming image/html', async () => {
+    const response = await createWithImage(
+      Buffer.from('<html><script>alert(document.cookie)</script></html>'),
+      'evil.html',
+      'image/html',
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('rejects an SVG-disguised-as-PNG payload claiming image/png', async () => {
+    const response = await createWithImage(
+      Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      ),
+      'evil.png',
+      'image/png',
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('rejects a .php extension even with real PNG bytes and image/png MIME', async () => {
+    const response = await createWithImage(
+      minimalPng,
+      'shell.php',
+      'image/png',
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('accepts a legitimate PNG and stores it with a .png extension', async () => {
+    const response = await createWithImage(
+      minimalPng,
+      'diagram.png',
+      'image/png',
+    );
+    expect(response.status).toBe(200);
+    expect((response.body as { game: string }).game).toBeDefined();
+  });
+
+  it('sets X-Content-Type-Options: nosniff on image responses', async () => {
+    const createResponse = await createWithImage(
+      minimalPng,
+      'diagram.png',
+      'image/png',
+    );
+    const createBody = createResponse.body as {
+      game: string;
+      credentials: string[];
+    };
+
+    const imageResponse = await request(publicApiServer.callback())
+      .get(`/game/${createBody.game}/image`)
+      .auth('0', createBody.credentials[0]!);
+
+    expect(imageResponse.headers['x-content-type-options']).toBe('nosniff');
+  });
+});
+
 describe('authentication', () => {
   const endpoints = ['players', 'model', 'download', 'download/text'];
   let matchID: string | null = null;

--- a/apps/server/src/publicApi.ts
+++ b/apps/server/src/publicApi.ts
@@ -51,6 +51,22 @@ const runPublicApi = (gameServer: GameServer): [Koa, Server] => {
   );
 
   app.use(cors());
+  app.use(async (ctx, next) => {
+    await next();
+    // Prevent MIME-type sniffing so an attacker-controlled extension stored on
+    // disk cannot cause the browser to interpret an upload as active content.
+    ctx.set('X-Content-Type-Options', 'nosniff');
+    // Restrict where this origin may be embedded to prevent clickjacking.
+    ctx.set('X-Frame-Options', 'DENY');
+    // Defense-in-depth against stored XSS via uploaded content: only allow
+    // same-origin scripts. Inline styles are permitted because the React build
+    // injects styles at runtime; images may come from data/blob URLs (client
+    // diagram rendering) or same-origin uploads. WebSockets use ws/wss.
+    ctx.set(
+      'Content-Security-Policy',
+      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'",
+    );
+  });
   app.use(router.routes()).use(router.allowedMethods());
   const appHandle = app.listen(API_PORT, () => {
     console.log(`Public API serving at: http://localhost:${API_PORT}/`);


### PR DESCRIPTION
Image uploads to POST /api/game/create were validated only by trusting the client-supplied Content-Type header and filename extension, which allowed an attacker to upload arbitrary file types (e.g. PHP, HTML) by spoofing the multipart Content-Type (CWE-434). The server now enforces a strict allowlist (PNG, JPEG, GIF, WebP, SVG) and verifies the actual file content via magic-byte sniffing, so the client-supplied MIME type and extension can no longer bypass validation on their own. The stored file extension is derived from the server allowlist rather than the client-supplied filename.

Additionally, X-Content-Type-Options: nosniff, X-Frame-Options: DENY, and a strict Content-Security-Policy are now set on both the API (Koa) and the static client (nginx) responses as defense-in-depth against stored XSS via content-type confusion.

Regression tests cover the exact PoC from the report (PHP/HTML/SVG-as-PNG payloads are rejected; legitimate PNG uploads are accepted).