### PR TITLE
WIP: feat: add Threat Dragon schema v2 support alongside v1

### DIFF
--- a/.changeset/fix-jsdom-resolution.md
+++ b/.changeset/fix-jsdom-resolution.md
@@ -1,0 +1,11 @@
+---
+"@eop/root": patch
+---
+
+Fix jsdom resolution failure in client tests. jsdom was only declared as a
+devDependency of @eop/client, so npm hoisted it to apps/client/node_modules
+instead of the root node_modules. vitest's worker (located at the root
+node_modules) imports jsdom via a bare specifier using Node's ESM resolver,
+which could not resolve it from outside the client workspace. Adding jsdom
+to the root devDependencies ensures it is hoisted to the root node_modules
+where vitest can resolve it.

--- a/apps/client/src/components/board/board.tsx
+++ b/apps/client/src/components/board/board.tsx
@@ -17,7 +17,7 @@ import Timer from '../timer/timer';
 
 import './board.css';
 
-import type { GameState, ThreatDragonModel } from '@eop/shared';
+import type { AnyThreatDragonModel, GameState } from '@eop/shared';
 
 type BoardProps = Pick<
   BoardgameIOBoardProps<GameState>,
@@ -38,7 +38,9 @@ const Board: FC<BoardProps> = ({
 
   const [names, setNames] = useState(initialNames);
 
-  const [model, setModel] = useState<ThreatDragonModel | undefined>(undefined);
+  const [model, setModel] = useState<AnyThreatDragonModel | undefined>(
+    undefined,
+  );
   const apiBase = '/api';
 
   const updateName = useCallback((index: number, name: string) => {
@@ -84,7 +86,7 @@ const Board: FC<BoardProps> = ({
     // TODO: Type with valibot and consider using react-query.
     const body = await apiGetRequest('model');
 
-    const model = body as ThreatDragonModel | undefined;
+    const model = body as AnyThreatDragonModel | undefined;
 
     setModel(model);
   }, [apiGetRequest]);

--- a/apps/client/src/components/model/model.tsx
+++ b/apps/client/src/components/model/model.tsx
@@ -10,12 +10,13 @@ import '../../jointjs/shapes';
 
 import './model.css';
 
-import type { ThreatDragonModel } from '@eop/shared';
+import { getModelAdapter } from '@eop/shared';
+import type { AnyThreatDragonModel } from '@eop/shared';
 
 const SCROLL_SPEED = 1000;
 
 type ModelProps = {
-  model: ThreatDragonModel;
+  model: AnyThreatDragonModel;
   selectedDiagram: number;
   selectedComponent: string;
   onSelectDiagram?: (id: number) => void;
@@ -62,17 +63,24 @@ const Model: FC<ModelProps> = ({
   const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
 
   useEffect(() => {
-    graph.fromJSON(model.detail.diagrams[selectedDiagram]?.diagramJson);
-    //paper.fitToContent(1, 1, 10, { allowNewOrigin: "any" });
+    const jointJson = getModelAdapter(model).toJointGraph(
+      model,
+      selectedDiagram,
+    );
+    if (!jointJson || !jointJson.cells || jointJson.cells.length === 0) {
+      graph.clear();
+      return;
+    }
+    graph.fromJSON(jointJson);
   }, [graph, model, selectedDiagram]);
 
   useEffect(() => {
     // unhighlight all
     paper.model.getElements().forEach((e) => {
-      paper.findViewByModel(e).unhighlight();
+      paper.findViewByModel(e)?.unhighlight();
     });
     paper.model.getLinks().forEach((e) => {
-      paper.findViewByModel(e).unhighlight();
+      paper.findViewByModel(e)?.unhighlight();
     });
 
     // highlight the selected component

--- a/apps/client/src/components/threatbar/threatbar.test.tsx
+++ b/apps/client/src/components/threatbar/threatbar.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 
 import Threatbar from './threatbar';
 
-import type { GameState, ThreatDragonModel } from '@eop/shared';
+import type { GameState, ThreatDragonModelV1 } from '@eop/shared';
 
 describe('<Threatbar>', () => {
   const selectedDiagram = 0;
@@ -49,7 +49,7 @@ describe('<Threatbar>', () => {
   };
 
   it('shows identified threats in reverse order', () => {
-    const model: ThreatDragonModel = {
+    const model: ThreatDragonModelV1 = {
       summary: {
         title: 'title',
       },
@@ -121,7 +121,7 @@ describe('<Threatbar>', () => {
   });
 
   it('shows existing threats in reverse order', () => {
-    const model: ThreatDragonModel = {
+    const model: ThreatDragonModelV1 = {
       summary: {
         title: 'title',
       },

--- a/apps/client/src/components/threatbar/threatbar.tsx
+++ b/apps/client/src/components/threatbar/threatbar.tsx
@@ -1,4 +1,4 @@
-import { getComponentName, getSuitDisplayName } from '@eop/shared';
+import { getModelAdapter, getSuitDisplayName } from '@eop/shared';
 import {
   faBolt,
   faEdit,
@@ -24,18 +24,13 @@ import ThreatModal from '../threatmodal/threatmodal';
 
 import './threatbar.css';
 
-import type {
-  GameState,
-  ThreatDragonModel,
-  ThreatDragonThreat,
-} from '@eop/shared';
+import type { AnyThreatDragonModel, GameState, Threat } from '@eop/shared';
 import type { BoardProps } from 'boardgame.io/react';
 import type { FC } from 'react';
-import { Threat } from '../../../../../packages/shared/dist/types/game/threat';
 import { nl2br } from '../../utils/nl2br';
 
 type ThreatbarProps = {
-  model?: ThreatDragonModel;
+  model?: AnyThreatDragonModel;
   active: boolean;
   names: string[];
   isInThreatStage: boolean;
@@ -50,25 +45,23 @@ const Threatbar: FC<ThreatbarProps> = ({
   names,
   isInThreatStage,
 }) => {
+  const adapter = model ? getModelAdapter(model) : undefined;
+
   const getSelectedComponent = () => {
-    if (G.selectedComponent === '' || model === undefined) {
+    if (G.selectedComponent === '' || model === undefined || !adapter) {
       return undefined;
     }
-
-    const diagram = model.detail.diagrams[G.selectedDiagram]?.diagramJson;
-    return diagram?.cells?.find((cell) => cell.id === G.selectedComponent);
+    return adapter.findCell(model, G.selectedDiagram, G.selectedComponent);
   };
 
-  const getThreatsForSelectedComponent = (): ThreatDragonThreat[] => {
+  const getThreatsForSelectedComponent = () => {
     const component = getSelectedComponent();
-
-    return (
-      component?.threats?.map((threat, index) => ({
-        ...threat,
-        // add ids if they are missing
-        id: threat.id ?? `${index}`,
-      })) ?? []
-    );
+    if (!component || !adapter) return [];
+    return adapter.getCellThreats(component).map((threat, index) => ({
+      ...threat,
+      // add ids if they are missing
+      id: threat.id ?? `${index}`,
+    }));
   };
 
   const getIdentifiedThreatsForSelectedComponent = () =>
@@ -80,7 +73,7 @@ const Threatbar: FC<ThreatbarProps> = ({
   const identifiedThreats =
     getIdentifiedThreatsForSelectedComponent().reverse();
   const component = getSelectedComponent();
-  const componentName = getComponentName(component);
+  const componentName = adapter?.getComponentName(component) ?? '';
 
   const [threatToBeDeleted, setThreatToBeDeleted] = useState<
     Threat | undefined
@@ -179,7 +172,7 @@ const Threatbar: FC<ThreatbarProps> = ({
             </em>
           )}
           <hr />
-          {threats.map((val: ThreatDragonThreat, idx: number) => (
+          {threats.map((val, idx) => (
             <Card key={idx}>
               <CardHeader
                 className="hoverable"

--- a/apps/client/src/pages/create.tsx
+++ b/apps/client/src/pages/create.tsx
@@ -12,7 +12,9 @@ import {
   ModelType,
   SPECTATOR,
   Suit,
+  validateThreatDragonModel,
 } from '@eop/shared';
+import type { AnyThreatDragonModel } from '@eop/shared';
 import { ChangeEvent, FC, useState } from 'react';
 import {
   Button,
@@ -53,7 +55,10 @@ const Create: FC = () => {
   const [creating, setCreating] = useState(false);
   const [created, setCreated] = useState(false);
   const [modelType, setModelType] = useState(ModelType.IMAGE);
-  const [model, setModel] = useState<Record<string, unknown> | undefined>(
+  const [model, setModel] = useState<AnyThreatDragonModel | undefined>(
+    undefined,
+  );
+  const [modelVersion, setModelVersion] = useState<'v1' | 'v2' | undefined>(
     undefined,
   );
   const [image, setImage] = useState<File | undefined>(undefined);
@@ -112,7 +117,15 @@ const Create: FC = () => {
       );
     }
 
-    setModel(JSON.parse(await readFileAsText(file)) as Record<string, unknown>);
+    const parsed: unknown = JSON.parse(await readFileAsText(file));
+    const { valid, version, errors } = validateThreatDragonModel(parsed);
+    if (!valid) {
+      setModel(undefined);
+      setModelVersion(undefined);
+      throw new Error(`Invalid Threat Dragon model: ${errors.join('; ')}`);
+    }
+    setModel(parsed as AnyThreatDragonModel);
+    setModelVersion(version);
   };
 
   const updateImage = (e: ChangeEvent<HTMLInputElement>) => {
@@ -369,15 +382,32 @@ const Create: FC = () => {
                   >
                     Threat Dragon
                   </a>
-                  . Or download a{' '}
+                  . Schema versions 1 and 2 are both supported. Or download a{' '}
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
                     href="https://raw.githubusercontent.com/mike-goodwin/owasp-threat-dragon-demo/master/ThreatDragonModels/Demo%20Threat%20Model/Demo%20Threat%20Model.json"
                   >
-                    sample model
+                    sample v1 model
+                  </a>{' '}
+                  or a{' '}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://raw.githubusercontent.com/OWASP/threat-dragon/main/ThreatDragonModels/v2-threat-model.json"
+                  >
+                    sample v2 model
                   </a>{' '}
                   to try it out.
+                  {model !== undefined && modelVersion !== undefined && (
+                    <>
+                      {' '}
+                      <span className="text-success">
+                        (Valid {modelVersion === 'v2' ? 'V2' : 'V1'} model
+                        loaded)
+                      </span>
+                    </>
+                  )}
                 </FormText>
               </FormGroup>
             </FormGroup>

--- a/apps/server/src/ModelFlatFile.ts
+++ b/apps/server/src/ModelFlatFile.ts
@@ -1,6 +1,6 @@
 import { FlatFile } from 'boardgame.io/server';
 
-import type { ThreatDragonModel } from '@eop/shared';
+import type { AnyThreatDragonModel } from '@eop/shared';
 import type { StorageAPI } from 'boardgame.io';
 import type { Object } from 'ts-toolbelt';
 
@@ -8,7 +8,7 @@ interface ModelFetchOpts extends StorageAPI.FetchOpts {
   model?: boolean;
 }
 
-type Model = ThreatDragonModel | { extension: string };
+type Model = AnyThreatDragonModel | { extension: string };
 
 interface ModelFetchFields extends StorageAPI.FetchFields {
   model: Model | null;

--- a/apps/server/src/endpoints.ts
+++ b/apps/server/src/endpoints.ts
@@ -7,15 +7,17 @@ import {
   gameName,
   GameState,
   getImageExtension,
+  getModelAdapter,
   getSuitDisplayName,
   isSuit,
   logEvent,
   ModelType,
   SetupData,
   SUITS,
-  ThreatDragonModel,
   ThreatDragonThreat,
+  validateThreatDragonModel,
 } from '@eop/shared';
+import type { AnyThreatDragonModel } from '@eop/shared';
 import { LobbyClient } from 'boardgame.io/client';
 import send from 'koa-send';
 import { v4 as uuidv4 } from 'uuid';
@@ -78,11 +80,15 @@ export const createGame =
       //model stuff
       switch (body.modelType) {
         case ModelType.THREAT_DRAGON: {
-          // TODO: validation
-          await gameServer.db.setModel(
-            matchID,
-            JSON.parse(body.model as string) as ThreatDragonModel,
-          );
+          const parsed: unknown = JSON.parse(body.model as string);
+          const { valid, errors } = validateThreatDragonModel(parsed);
+          if (!valid) {
+            return ctx.throw(
+              `Invalid Threat Dragon model: ${errors.join('; ')}`,
+              400,
+            );
+          }
+          await gameServer.db.setModel(matchID, parsed as AnyThreatDragonModel);
           break;
         }
 
@@ -187,7 +193,12 @@ export const getImage =
 
     const game = await gameServer.db.fetch(matchID, { model: true });
 
-    if (!game.model || !('extension' in game.model)) {
+    const model = game.model;
+    if (
+      !model ||
+      !('extension' in model) ||
+      typeof (model as { extension?: unknown }).extension !== 'string'
+    ) {
       return ctx.throw(
         'Cannot request image if none is stored, maybe the wrong model type has been set?',
         400,
@@ -195,9 +206,13 @@ export const getImage =
     }
 
     //send image
-    await send(ctx, `${matchID}.${game.model?.extension}`, {
-      root: getDbImagesFolder(),
-    });
+    await send(
+      ctx,
+      `${matchID}.${(model as { extension: string }).extension}`,
+      {
+        root: getDbImagesFolder(),
+      },
+    );
   };
 
 const getMethodologyName = (gameMode: GameMode) => {
@@ -245,19 +260,19 @@ export const downloadThreatDragonModel =
     }
 
     // update the model with the identified threats
+    const adapter = getModelAdapter(model);
     state.G.identifiedThreats.forEach((threatsForComponent, diagramIdx) => {
       if (threatsForComponent === null) {
         return;
       }
       Object.keys(threatsForComponent).forEach((componentIdx) => {
-        const diagram = model.detail.diagrams[diagramIdx]?.diagramJson;
-        const cell = diagram?.cells?.find((c) => c.id === componentIdx);
+        const cell = adapter.findCell(model, diagramIdx, componentIdx);
 
         if (
           cell !== undefined &&
           threatsForComponent[componentIdx] !== undefined
         ) {
-          const threats: ThreatDragonThreat[] = cell.threats ?? [];
+          const threats: ThreatDragonThreat[] = adapter.getCellThreats(cell);
           Object.values(threatsForComponent[componentIdx]).forEach((t) =>
             threats.push({
               description: t.description ?? '',
@@ -276,7 +291,7 @@ export const downloadThreatDragonModel =
               game: matchID,
             }),
           );
-          cell.threats = threats;
+          adapter.setCellThreats(cell, threats);
         }
       });
     });
@@ -362,7 +377,7 @@ function enrichThreatWithCategory(
 function getThreats(
   gameState: State<GameState>,
   metadata: Server.MatchData,
-  model: ThreatDragonModel | null,
+  model: AnyThreatDragonModel | null,
 ) {
   const threats: ThreatDragonThreat[] = [];
 
@@ -393,10 +408,13 @@ function getThreats(
 
   //add threats from model
   if (model) {
-    model.detail.diagrams.forEach((diagram) => {
-      diagram.diagramJson.cells?.forEach((cell) => {
-        if (cell.threats !== undefined) {
-          threats.push(...cell.threats);
+    const adapter = getModelAdapter(model);
+    model.detail.diagrams.forEach((_diagram, di) => {
+      const cells = adapter.getDiagramCells(model, di);
+      cells?.forEach((cell) => {
+        const t = adapter.getCellThreats(cell);
+        if (t.length) {
+          threats.push(...t);
         }
       });
     });

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -18,7 +18,7 @@ import {
   publicApiServerHandle,
 } from './main';
 
-import type { ThreatDragonModel } from '@eop/shared';
+import type { ThreatDragonModelV1, ThreatDragonModelV2 } from '@eop/shared';
 import type { LobbyAPI, Server, State } from 'boardgame.io';
 
 beforeEach(() => {
@@ -86,6 +86,21 @@ it('retrieves player info for a game', async () => {
 
 it('creates a game with a model', async () => {
   const names = ['P1', 'P2', 'P3'];
+  const model: ThreatDragonModelV1 = {
+    summary: { title: 'Test' },
+    detail: {
+      diagrams: [
+        {
+          id: 0,
+          title: '',
+          diagramType: 'STRIDE',
+          thumbnail: '',
+          size: { width: 0, height: 0 },
+          diagramJson: { cells: [] },
+        },
+      ],
+    },
+  };
   const response = await request(publicApiServer.callback())
     .post('/game/create')
     .field('startSuit', 'A')
@@ -93,7 +108,7 @@ it('creates a game with a model', async () => {
     .field('turnDuration', '5')
     .field('names[]', names)
     .field('modelType', ModelType.THREAT_DRAGON)
-    .field('model', JSON.stringify({})); // TODO: add proper model because this will fail when validation of the model is added
+    .field('model', JSON.stringify(model));
 
   const body = response.body as {
     game: string;
@@ -109,7 +124,21 @@ it('creates a game with a model', async () => {
 });
 
 it('retrieve the model for a game', async () => {
-  const model = { foo: 'bar' }; // TODO add proper model because this will break when validation of the model is added
+  const model: ThreatDragonModelV1 = {
+    summary: { title: 'Test' },
+    detail: {
+      diagrams: [
+        {
+          id: 0,
+          title: '',
+          diagramType: 'STRIDE',
+          thumbnail: '',
+          size: { width: 0, height: 0 },
+          diagramJson: { cells: [] },
+        },
+      ],
+    },
+  };
 
   const names = ['P1', 'P2', 'P3'];
   const createResponse = await request(publicApiServer.callback())
@@ -192,7 +221,7 @@ it('download the final model for a game', async () => {
     updatedAt: 0,
   };
 
-  const model: ThreatDragonModel = {
+  const model: ThreatDragonModelV1 = {
     summary: {
       title: 'Foo',
     },
@@ -243,7 +272,7 @@ it('download the final model for a game', async () => {
     .get(`/game/${matchID}/download`)
     .auth('0', 'abc123');
 
-  const body = response.body as ThreatDragonModel;
+  const body = response.body as ThreatDragonModelV1;
   const threats = body.detail.diagrams[0]?.diagramJson.cells?.[0]?.threats;
 
   expect(threats?.[0]?.id).toBe('0');
@@ -252,6 +281,99 @@ it('download the final model for a game', async () => {
   expect(threats?.[0]?.description).toBe('description');
   expect(threats?.[0]?.mitigation).toBe('mitigation');
   expect(threats?.[0]?.game).toBe(matchID);
+});
+
+it('download the final model for a game (V2)', async () => {
+  const matchID = 'v2-download-test';
+
+  const state = {
+    G: {
+      modelType: ModelType.THREAT_DRAGON,
+      gameMode: GameMode.EOP,
+      identifiedThreats: [
+        {
+          'component-1': {
+            'threat-1': {
+              id: '0',
+              severity: 'High',
+              type: 'D',
+              title: 'title',
+              description: 'description',
+              mitigation: 'mitigation',
+              owner: '0',
+            },
+          },
+        },
+      ],
+    },
+  } as State;
+
+  const metadata: Server.MatchData = {
+    gameName: 'some game',
+    players: {
+      0: { id: 0, name: 'P1', credentials: 'abc123' },
+      1: { id: 1, name: 'P2', credentials: '123abc' },
+    },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const model: ThreatDragonModelV2 = {
+    version: '2.0.0',
+    summary: { title: 'Bar' },
+    detail: {
+      contributors: [],
+      reviewer: '',
+      diagramTop: 1,
+      threatTop: 0,
+      diagrams: [
+        {
+          id: 0,
+          title: '',
+          diagramType: 'STRIDE',
+          thumbnail: '',
+          version: '2.0.0',
+          cells: [
+            {
+              id: 'component-1',
+              shape: 'actor',
+              zIndex: 0,
+              position: { x: 0, y: 0 },
+              size: { width: 0, height: 0 },
+              attrs: {},
+              data: {
+                type: 'tm.Actor',
+                name: '',
+                hasOpenThreats: false,
+                threats: [],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  await gameServer.db.setMetadata(matchID, metadata);
+  await gameServer.db.setModel(matchID, model);
+  await gameServer.db.setState(matchID, state);
+
+  const response = await request(publicApiServer.callback())
+    .get(`/game/${matchID}/download`)
+    .auth('0', 'abc123');
+
+  const body = response.body as ThreatDragonModelV2;
+  const threats = body.detail.diagrams[0]?.cells?.[0]?.data?.threats;
+
+  expect(threats?.[0]?.id).toBe('0');
+  expect(threats?.[0]?.type).toBe('Spoofing');
+  expect(threats?.[0]?.title).toBe('title');
+  expect(threats?.[0]?.description).toBe('description');
+  expect(threats?.[0]?.mitigation).toBe('mitigation');
+  expect(threats?.[0]?.game).toBe(matchID);
+  // V2 structure preserved
+  expect(body.version).toBe('2.0.0');
+  expect(body.detail.diagramTop).toBe(1);
 });
 
 it('Download threat file', async () => {
@@ -303,7 +425,7 @@ it('Download threat file', async () => {
   } as State;
 
   //Maybe I should put these jsons into a file
-  const model: ThreatDragonModel = {
+  const model: ThreatDragonModelV1 = {
     summary: {
       title: '  Demo Threat Model ',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
+        "jsdom": "^28.1.0",
         "sherif": "^1.10.0",
         "turbo": "^2.5.8"
       },
@@ -57,173 +58,6 @@
         "typescript-eslint": "^8.53.1",
         "vite": "^7.3.3",
         "vitest": "^4.0.17"
-      }
-    },
-    "apps/client/node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/client/node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "apps/client/node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
-      }
-    },
-    "apps/client/node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "apps/client/node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "apps/client/node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "apps/client/node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "apps/client/node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0"
-    },
-    "apps/client/node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "apps/client/node_modules/@rolldown/pluginutils": {
@@ -469,36 +303,6 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
-    "apps/client/node_modules/cssstyle": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
-      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "apps/client/node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "apps/client/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -515,70 +319,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "apps/client/node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "apps/client/node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
-        "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "apps/client/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "apps/client/node_modules/picomatch": {
@@ -681,41 +421,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "apps/client/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "apps/client/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "apps/client/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "apps/server": {
@@ -1041,12 +746,60 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
       "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
@@ -1390,6 +1143,146 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@eop/client": {
@@ -4622,14 +4515,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -4641,6 +4534,22 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -4656,6 +4565,20 @@
       "dependencies": {
         "graphlib": "^2.1.8",
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -6204,6 +6127,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-assert": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
@@ -6877,6 +6813,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -7196,9 +7173,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -7243,9 +7220,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -10213,6 +10190,41 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@eop/root",
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
+    "jsdom": "^28.1.0",
     "sherif": "^1.10.0",
     "turbo": "^2.5.8"
   },

--- a/packages/shared/src/game/ThreatDragonModel.ts
+++ b/packages/shared/src/game/ThreatDragonModel.ts
@@ -1,385 +1,161 @@
 /**
- * The threat models used by OWASP Threat Dragon
+ * Threat Dragon model dispatcher.
  *
- * This type is based on the schema at https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V1.json
+ * This is the only place that knows about both V1 and V2. All call sites
+ * (endpoints, model rendering, threatbar) go through `getModelAdapter(model)`
+ * and never branch on version themselves. When V1 support is dropped, delete
+ * `ThreatDragonModel.v1.ts` and simplify this dispatcher to return `v2Adapter`
+ * directly — no call-site changes are required.
  */
-export interface ThreatDragonModel {
-  /**
-   * Threat Dragon version used in the model
-   */
-  version?: string;
+import { v1Adapter } from './ThreatDragonModel.v1';
+import type { ThreatDragonModelV1 } from './ThreatDragonModel.v1';
+import { v2Adapter } from './ThreatDragonModel.v2';
+import type { ThreatDragonModelV2 } from './ThreatDragonModel.v2';
 
-  /**
-   * Threat model project meta-data
-   */
-  summary: {
-    /**
-     * Description of the threat model used for report outputs
-     */
-    description?: string;
-    /**
-     * A unique identifier for this main threat model object
-     */
-    id?: number;
-    /**
-     * The original creator or overall owner of the model
-     */
-    owner?: string;
-    /**
-     * Threat model title
-     */
-    title: string;
-  };
-  /**
-   * Threat model definition
-   */
-  detail: {
-    /**
-     * An array of contributors to the threat model project
-     */
-    contributors?: Contributor[];
-    /**
-     * An array of single or multiple threat data-flow diagrams
-     */
-    diagrams: Diagram[];
-  };
-}
+// Re-export the versioned modules so consumers can `import { ... } from '@eop/shared'`.
+export * from './ThreatDragonModel.v1';
+export * from './ThreatDragonModel.v2';
 
-interface Contributor {
-  /**
-   * The name of the contributor
-   */
-  name: string;
-}
-
-interface Diagram {
-  /**
-   * The methodology used by the data-flow diagram
-   */
-  diagramType: string;
-  /**
-   * The sequence number of the diagram
-   */
-  id: number;
-  /**
-   * The size of the diagram drawing canvas
-   */
-  size: {
-    /**
-     * The height of the diagram drawing canvas
-     */
-    height: number;
-    /**
-     * The width of the diagram drawing canvas
-     */
-    width: number;
-  };
-  /**
-   * The path to the thumbnail image for the diagram
-   */
-  thumbnail: string;
-  /**
-   * The title of the data-flow diagram
-   */
-  title: string;
-  /**
-   * Threat Dragon version used in the diagram
-   */
-  version?: string;
-  /**
-   * The data-flow diagram components
-   */
-  diagramJson: DiagramJson;
-  /**
-   * The highest diagram number in the threat model
-   */
-  diagramTop?: number;
-  /**
-   * The reviewer of the overall threat model
-   */
-  reviewer?: string;
-  /**
-   * The highest threat number in the threat model
-   */
-  threatTop?: number;
-}
-
-interface DiagramJson {
-  /**
-   * The individual diagram components
-   */
-  cells?: ThreatDragonComponent[];
-}
-
-export interface ThreatDragonComponent {
-  /**
-   * The component display attributes
-   */
-  attrs: {
-    /**
-     * The component shape attributes
-     */
-    '.element-shape'?: {
-      /**
-       * The component shape display attributes
-       */
-      class?: string;
-    };
-    /**
-     * The component text
-     */
-    text?: {
-      /**
-       * The component text contents
-       */
-      text: string;
-    };
-    /**
-     * The component text attributes
-     */
-    '.element-text'?: {
-      /**
-       * The component text display attributes
-       */
-      class?: string;
-    };
-  };
-  /**
-   * The component rotation angle
-   */
-  angle?: number;
-  /**
-   * The component description
-   */
-  description?: string;
-  /**
-   * The component flag set if the process handles credit card payment
-   */
-  handlesCardPayment?: boolean;
-  /**
-   * The component flag set if the process is part of a retail site
-   */
-  handlesGoodsOrServices?: boolean;
-  /**
-   * The component flag set if there are open threats
-   */
-  hasOpenThreats?: boolean;
-  /**
-   * The component unique identifier (UUID)
-   */
-  id: string;
-  /**
-   * The component flag set if the store contains logs
-   */
-  isALog?: boolean;
-  /**
-   * The component flag set if the process is a web application
-   */
-  isWebApplication?: boolean;
-  /**
-   * The component flag set if the data flow or store is encrypted
-   */
-  isEncrypted?: boolean;
-  /**
-   * The component flag set if the data store uses signatures
-   */
-  isSigned?: boolean;
-  /**
-   * The flag set if the component is a trust boundary curve or trust boundary box
-   */
-  isTrustBoundary?: boolean;
-  /**
-   * The floating labels used for boundary or data-flow
-   */
-  labels?: Label[];
-  /**
-   * The component flag set if it is not in scope
-   */
-  outOfScope?: boolean;
-  /**
-   * The component position
-   */
-  position?: {
-    /**
-     * The component horizontal position
-     */
-    x: number;
-    /**
-     * The component vertical position
-     */
-    y: number;
-    [k: string]: unknown;
-  };
-  /**
-   * The component's level of privilege/permissions
-   */
-  privilegeLevel?: string;
-  /**
-   * The component description if out of scope
-   */
-  reasonOutOfScope?: string;
-  /**
-   * The component size
-   */
-  size: {
-    /**
-     * The component height
-     */
-    height: number;
-    /**
-     * The component width
-     */
-    width: number;
-  };
-  /**
-   * The component curve type, for data flows and boundaries
-   */
-  smooth?: boolean;
-  /**
-   * The component curve source
-   */
-  source?: {
-    /**
-     * The data-flow source component
-     */
-    id?: string;
-    /**
-     * The boundary horizontal curve source
-     */
-    x?: number;
-    /**
-     * The boundary vertical curve source
-     */
-    y?: number;
-  };
-  /**
-   * The component flag set if store contains credentials/PII
-   */
-  storesCredentials?: boolean;
-  /**
-   * The component flag set if store is part of a retail web application
-   */
-  storesInventory?: boolean;
-  /**
-   * The component curve target
-   */
-  target?: {
-    /**
-     * The data-flow target component
-     */
-    id?: string;
-    /**
-     * The boundary horizontal curve target
-     */
-    x?: number;
-    /**
-     * The boundary vertical curve target
-     */
-    y?: number;
-  };
-  /**
-   * The threats associated with the component
-   */
-  threats?: ThreatDragonThreat[];
-  type: CellType;
-  /**
-   * The boundary or data-flow curve points
-   */
-  vertices?: {
-    /**
-     * The horizontal value of the curve point
-     */
-    x: number;
-    /**
-     * The vertical value of the curve point
-     */
-    y: number;
-  };
-  z: number;
-}
-
-interface Label {
-  /**
-   * The label position
-   */
-  position: number;
-  /**
-   * The label text attributes
-   */
-  attrs: {
-    /**
-     * The text attributes
-     */
-    text: {
-      /**
-       * The text size
-       */
-      'font-size': string;
-      /**
-       * The text weight
-       */
-      'font-weight': string;
-      /**
-       * The text content
-       */
-      text: string;
-    };
-  };
-}
-
-type CellType =
-  | 'tm.Process'
-  | 'tm.Store'
-  | 'tm.Actor'
-  | 'tm.Flow'
-  | 'tm.Boundary';
-
+/**
+ * Threat Dragon threat structure. This is identical between V1 and V2, so it
+ * lives here as a shared type.
+ */
 export interface ThreatDragonThreat {
-  /**
-   * The threat description
-   */
   description: string;
-  /**
-   * The threat mitigation
-   */
   mitigation: string;
-  /**
-   * The threat methodology type
-   */
   modelType?: string;
-  /**
-   * The unique number for the threat
-   */
   number?: number;
-  /**
-   * The custom score/risk for the threat
-   */
   score?: string;
-  /**
-   * The threat severity as High, Medium or Low
-   */
   severity: string;
-  /**
-   * The threat status as NA, Open or Mitigated
-   */
-  status: Status;
-  /**
-   * The threat ID as a UUID
-   */
+  status: string;
   threatId?: string;
-  /**
-   * The threat title
-   */
   title: string;
-  /**
-   * The threat type, selection according to modelType
-   */
   type: string;
 
-  // our custom properties
+  // custom properties added by EoP
   owner?: string;
   id?: string;
   game?: string;
+  [k: string]: unknown;
 }
 
-type Status = 'NA' | 'Open' | 'Mitigated';
+/**
+ * Union of both supported model versions.
+ */
+export type AnyThreatDragonModel = ThreatDragonModelV1 | ThreatDragonModelV2;
+
+/**
+ * Common contract for version-specific operations. Each version module
+ * implements this interface; the dispatcher selects the right one.
+ */
+export interface ThreatModelAdapter<M = AnyThreatDragonModel, C = unknown> {
+  getDiagramCells(model: M, diagramIdx: number): C[] | undefined;
+  findCell(model: M, diagramIdx: number, cellId: string): C | undefined;
+  getCellThreats(cell: C): ThreatDragonThreat[];
+  setCellThreats(cell: C, threats: ThreatDragonThreat[]): void;
+  getComponentName(component: C | undefined): string;
+  toJointGraph(model: M, diagramIdx: number): { cells: unknown[] };
+  validate(model: unknown): { valid: boolean; errors: string[] };
+}
+
+/**
+ * Detect whether a model is a V2 model.
+ *
+ * V2 models place `cells` directly on the diagram object, whereas V1 models
+ * nest cells under `diagramJson`. We check the first diagram that has either
+ * `cells` or `diagramJson`, falling back to scanning all diagrams if the first
+ * is empty.
+ */
+export function isThreatDragonModelV2(
+  model: AnyThreatDragonModel,
+): model is ThreatDragonModelV2 {
+  const diagrams = model.detail?.diagrams;
+  if (!Array.isArray(diagrams)) return false;
+
+  for (const d of diagrams) {
+    const diag = d as { cells?: unknown; diagramJson?: unknown };
+    if (diag.cells !== undefined) return true;
+    if (diag.diagramJson !== undefined) return false;
+  }
+
+  // No diagram exposed cells/diagramJson — treat presence of V2-only
+  // detail counters as a signal, otherwise default to V1.
+  const detail = model.detail as {
+    diagramTop?: unknown;
+    threatTop?: unknown;
+  };
+  return detail.diagramTop !== undefined || detail.threatTop !== undefined;
+}
+
+export function getModelVersion(model: AnyThreatDragonModel): 'v1' | 'v2' {
+  return isThreatDragonModelV2(model) ? 'v2' : 'v1';
+}
+
+/**
+ * The only place that selects between V1 and V2 adapters.
+ */
+export function getModelAdapter(
+  model: AnyThreatDragonModel,
+): ThreatModelAdapter {
+  return isThreatDragonModelV2(model)
+    ? (v2Adapter as ThreatModelAdapter)
+    : (v1Adapter as ThreatModelAdapter);
+}
+
+/**
+ * Upload-time validation + version detection. Returns the detected version
+ * (if any) and validation errors. Used by the create-game endpoint and the
+ * create page UI.
+ */
+export function validateThreatDragonModel(raw: unknown): {
+  valid: boolean;
+  version?: 'v1' | 'v2';
+  errors: string[];
+} {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { valid: false, errors: ['Model must be an object'] };
+  }
+
+  const model = raw as Record<string, unknown>;
+  const detail = model.detail as
+    | { diagrams?: unknown[]; diagramTop?: unknown; threatTop?: unknown }
+    | undefined;
+
+  if (!detail || !Array.isArray(detail.diagrams)) {
+    return {
+      valid: false,
+      errors: ['detail.diagrams must be an array'],
+    };
+  }
+
+  // Detect version: any diagram with `cells` (directly) means V2.
+  let looksV2 = false;
+  let looksV1 = false;
+  for (const d of detail.diagrams) {
+    const diag = d as { cells?: unknown; diagramJson?: unknown } | null;
+    if (diag && diag.cells !== undefined) looksV2 = true;
+    if (diag && diag.diagramJson !== undefined) looksV1 = true;
+  }
+  if (!looksV2 && !looksV1) {
+    // fall back to V2-only detail counters
+    looksV2 = detail.diagramTop !== undefined || detail.threatTop !== undefined;
+  }
+
+  const version: 'v1' | 'v2' | undefined =
+    looksV2 && !looksV1 ? 'v2' : looksV1 && !looksV2 ? 'v1' : undefined;
+
+  // If both signals present (mixed), prefer V2 — the V2 adapter's dual-read
+  // for threats tolerates V1-shaped `cell.threats` as a fallback.
+  const effectiveVersion = version ?? 'v2';
+  const adapter =
+    effectiveVersion === 'v2'
+      ? (v2Adapter as ThreatModelAdapter)
+      : (v1Adapter as ThreatModelAdapter);
+
+  const result = adapter.validate(raw);
+  return {
+    valid: result.valid,
+    version: effectiveVersion,
+    errors: result.errors,
+  };
+}

--- a/packages/shared/src/game/ThreatDragonModel.v1.test.ts
+++ b/packages/shared/src/game/ThreatDragonModel.v1.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+
+import { v1Adapter } from './ThreatDragonModel.v1';
+import type {
+  ThreatDragonComponentV1,
+  ThreatDragonModelV1,
+} from './ThreatDragonModel.v1';
+import type { ThreatDragonThreat } from './ThreatDragonModel';
+
+const actorCell: ThreatDragonComponentV1 = {
+  type: 'tm.Actor',
+  attrs: { text: { text: 'Bar' } },
+  id: 'some-id',
+  size: { width: 0, height: 0 },
+  z: 0,
+};
+
+const flowCell: ThreatDragonComponentV1 = {
+  type: 'tm.Flow',
+  labels: [
+    {
+      attrs: {
+        text: {
+          text: 'Bar',
+          'font-size': '12pt',
+          'font-weight': 'bold',
+        },
+      },
+      position: 0,
+    },
+  ],
+  attrs: {},
+  id: 'some-id',
+  size: { width: 0, height: 0 },
+  z: 0,
+};
+
+const model: ThreatDragonModelV1 = {
+  summary: { title: 'Test' },
+  detail: {
+    diagrams: [
+      {
+        id: 0,
+        title: 'Diagram 0',
+        diagramType: 'STRIDE',
+        thumbnail: '',
+        size: { width: 0, height: 0 },
+        diagramJson: {
+          cells: [actorCell, flowCell],
+        },
+      },
+    ],
+  },
+};
+
+describe('v1Adapter', () => {
+  describe('getDiagramCells', () => {
+    it('returns cells for an existing diagram', () => {
+      expect(v1Adapter.getDiagramCells(model, 0)).toHaveLength(2);
+    });
+
+    it('returns undefined for a missing diagram', () => {
+      expect(v1Adapter.getDiagramCells(model, 99)).toBeUndefined();
+    });
+  });
+
+  describe('findCell', () => {
+    it('finds a cell by id', () => {
+      expect(v1Adapter.findCell(model, 0, 'some-id')?.id).toBe('some-id');
+    });
+
+    it('returns undefined for a missing cell', () => {
+      expect(v1Adapter.findCell(model, 0, 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('getCellThreats / setCellThreats', () => {
+    it('reads threats from cell.threats', () => {
+      const cell: ThreatDragonComponentV1 = {
+        ...actorCell,
+        threats: [
+          {
+            title: 't',
+            status: 'Open',
+            severity: 'High',
+            description: '',
+            mitigation: '',
+            type: 'x',
+          },
+        ],
+      };
+      expect(v1Adapter.getCellThreats(cell)).toHaveLength(1);
+    });
+
+    it('returns empty array when no threats', () => {
+      expect(v1Adapter.getCellThreats(actorCell)).toEqual([]);
+    });
+
+    it('writes threats to cell.threats', () => {
+      const cell: ThreatDragonComponentV1 = { ...actorCell };
+      const t: ThreatDragonThreat = {
+        title: 't',
+        status: 'Open',
+        severity: 'High',
+        description: '',
+        mitigation: '',
+        type: 'x',
+      };
+      v1Adapter.setCellThreats(cell, [t]);
+      expect(cell.threats).toHaveLength(1);
+      expect(cell.threats?.[0]?.title).toBe('t');
+    });
+  });
+
+  describe('getComponentName', () => {
+    it('returns empty for undefined', () => {
+      expect(v1Adapter.getComponentName(undefined)).toBe('');
+    });
+
+    it('returns name for actor', () => {
+      expect(v1Adapter.getComponentName(actorCell)).toBe('Actor: Bar');
+    });
+
+    it('returns name for flow from labels', () => {
+      expect(v1Adapter.getComponentName(flowCell)).toBe('Flow: Bar');
+    });
+  });
+
+  describe('toJointGraph', () => {
+    it('returns diagramJson as-is (already JointJS-shaped)', () => {
+      const graph = v1Adapter.toJointGraph(model, 0);
+      expect(graph.cells).toHaveLength(2);
+      expect(graph.cells?.[0]).toBe(actorCell);
+    });
+
+    it('returns empty cells for missing diagram', () => {
+      expect(v1Adapter.toJointGraph(model, 99).cells).toEqual([]);
+    });
+  });
+
+  describe('validate', () => {
+    it('accepts a valid V1 model', () => {
+      expect(v1Adapter.validate(model).valid).toBe(true);
+    });
+
+    it('rejects non-object', () => {
+      expect(v1Adapter.validate(null).valid).toBe(false);
+    });
+
+    it('rejects missing summary.title', () => {
+      expect(v1Adapter.validate({ detail: { diagrams: [] } }).valid).toBe(
+        false,
+      );
+    });
+
+    it('rejects missing diagramJson', () => {
+      expect(
+        v1Adapter.validate({
+          summary: { title: 'x' },
+          detail: { diagrams: [{ id: 0 }] },
+        }).valid,
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/game/ThreatDragonModel.v1.ts
+++ b/packages/shared/src/game/ThreatDragonModel.v1.ts
@@ -1,0 +1,173 @@
+/**
+ * Threat Dragon V1 threat model types and adapter.
+ *
+ * This module is intentionally self-contained so that V1 support can be
+ * dropped in the future by deleting this single file (plus simplifying the
+ * dispatcher in `ThreatDragonModel.ts`).
+ *
+ * Based on the schema at
+ * https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V1.json
+ */
+import type {
+  ThreatDragonThreat,
+  ThreatModelAdapter,
+} from './ThreatDragonModel';
+
+export interface ThreatDragonModelV1 {
+  version?: string;
+  summary: {
+    description?: string;
+    id?: number;
+    owner?: string;
+    title: string;
+  };
+  detail: {
+    contributors?: ContributorV1[];
+    diagrams: DiagramV1[];
+  };
+}
+
+export interface ContributorV1 {
+  name: string;
+}
+
+export interface DiagramV1 {
+  diagramType: string;
+  id: number;
+  size: {
+    height: number;
+    width: number;
+  };
+  thumbnail: string;
+  title: string;
+  version?: string;
+  diagramJson: DiagramJsonV1;
+  diagramTop?: number;
+  reviewer?: string;
+  threatTop?: number;
+}
+
+export interface DiagramJsonV1 {
+  cells?: ThreatDragonComponentV1[];
+}
+
+export interface ThreatDragonComponentV1 {
+  attrs: {
+    '.element-shape'?: { class?: string };
+    text?: { text: string };
+    '.element-text'?: { class?: string };
+  };
+  angle?: number;
+  description?: string;
+  handlesCardPayment?: boolean;
+  handlesGoodsOrServices?: boolean;
+  hasOpenThreats?: boolean;
+  id: string;
+  isALog?: boolean;
+  isWebApplication?: boolean;
+  isEncrypted?: boolean;
+  isSigned?: boolean;
+  isTrustBoundary?: boolean;
+  labels?: LabelV1[];
+  outOfScope?: boolean;
+  position?: { x: number; y: number; [k: string]: unknown };
+  privilegeLevel?: string;
+  reasonOutOfScope?: string;
+  size: { height: number; width: number };
+  smooth?: boolean;
+  source?: { id?: string; x?: number; y?: number };
+  storesCredentials?: boolean;
+  storesInventory?: boolean;
+  target?: { id?: string; x?: number; y?: number };
+  threats?: ThreatDragonThreat[];
+  type: CellTypeV1;
+  vertices?: { x: number; y: number };
+  z: number;
+}
+
+export interface LabelV1 {
+  position: number;
+  attrs: {
+    text: {
+      'font-size': string;
+      'font-weight': string;
+      text: string;
+    };
+  };
+}
+
+export type CellTypeV1 =
+  | 'tm.Process'
+  | 'tm.Store'
+  | 'tm.Actor'
+  | 'tm.Flow'
+  | 'tm.Boundary';
+
+export const v1Adapter: ThreatModelAdapter<
+  ThreatDragonModelV1,
+  ThreatDragonComponentV1
+> = {
+  getDiagramCells(model, diagramIdx) {
+    return model.detail.diagrams[diagramIdx]?.diagramJson.cells;
+  },
+
+  findCell(model, diagramIdx, cellId) {
+    return model.detail.diagrams[diagramIdx]?.diagramJson.cells?.find(
+      (c) => c.id === cellId,
+    );
+  },
+
+  getCellThreats(cell) {
+    return cell.threats ?? [];
+  },
+
+  setCellThreats(cell, threats) {
+    cell.threats = threats;
+  },
+
+  getComponentName(component) {
+    if (component === undefined) return '';
+
+    const prefix = component.type.slice(3);
+
+    if (component.type === 'tm.Flow') {
+      return `${prefix}: ${component.labels?.[0]?.attrs.text.text}`;
+    }
+
+    return `${prefix}: ${component.attrs.text?.text}`;
+  },
+
+  toJointGraph(model, diagramIdx) {
+    const diagramJson = model.detail.diagrams[diagramIdx]?.diagramJson;
+    return { cells: diagramJson?.cells ?? [] };
+  },
+
+  validate(model) {
+    const errors: string[] = [];
+
+    if (typeof model !== 'object' || model === null || Array.isArray(model)) {
+      return { valid: false, errors: ['Model must be an object'] };
+    }
+
+    const m = model as Record<string, unknown>;
+    const summary = m.summary as Record<string, unknown> | undefined;
+    if (!summary || typeof summary.title !== 'string') {
+      errors.push('summary.title must be a string');
+    }
+
+    const detail = m.detail as Record<string, unknown> | undefined;
+    if (!detail || !Array.isArray(detail.diagrams)) {
+      errors.push('detail.diagrams must be an array');
+      return { valid: errors.length === 0, errors };
+    }
+
+    for (const [i, d] of (detail.diagrams as unknown[]).entries()) {
+      const diag = d as Record<string, unknown>;
+      if (!diag || typeof diag !== 'object' || !diag.diagramJson) {
+        errors.push(`diagram[${i}].diagramJson is missing`);
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  },
+};

--- a/packages/shared/src/game/ThreatDragonModel.v2.test.ts
+++ b/packages/shared/src/game/ThreatDragonModel.v2.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from 'vitest';
+
+import { v2Adapter } from './ThreatDragonModel.v2';
+import type { CellV2, ThreatDragonModelV2 } from './ThreatDragonModel.v2';
+import type { ThreatDragonThreat } from './ThreatDragonModel';
+
+const actorCell: CellV2 = {
+  id: 'actor-1',
+  shape: 'actor',
+  zIndex: 1,
+  position: { x: 10, y: 20 },
+  size: { width: 100, height: 80 },
+  attrs: { text: { text: 'Browser' } },
+  data: {
+    type: 'tm.Actor',
+    name: 'Browser',
+    hasOpenThreats: false,
+    threats: [],
+  },
+};
+
+const flowCell: CellV2 = {
+  id: 'flow-1',
+  shape: 'flow',
+  zIndex: 5,
+  attrs: {
+    line: { stroke: '#333', strokeWidth: 1, targetMarker: { name: 'block' } },
+  },
+  source: { cell: 'actor-1' },
+  target: { cell: 'process-1' },
+  vertices: [{ x: 100, y: 50 }],
+  connector: 'smooth',
+  labels: [
+    {
+      position: { distance: 0.5 },
+      attrs: { labelText: { text: 'Web Request' } },
+    },
+  ],
+  data: {
+    type: 'tm.Flow',
+    name: 'Web Request',
+    hasOpenThreats: false,
+    isEncrypted: true,
+    isPublicNetwork: true,
+    protocol: 'HTTP/S',
+  },
+};
+
+const boundaryBoxCell: CellV2 = {
+  id: 'bb-1',
+  shape: 'trust-boundary-box',
+  zIndex: 0,
+  position: { x: 0, y: 0 },
+  size: { width: 200, height: 200 },
+  attrs: {},
+  data: {
+    type: 'tm.BoundaryBox',
+    name: 'Boundary',
+    hasOpenThreats: false,
+    isTrustBoundary: true,
+  },
+};
+
+const model: ThreatDragonModelV2 = {
+  version: '2.0.0',
+  summary: { title: 'Test V2' },
+  detail: {
+    contributors: [],
+    diagrams: [
+      {
+        id: 0,
+        title: 'Main',
+        diagramType: 'STRIDE',
+        thumbnail: '',
+        version: '2.0.0',
+        cells: [actorCell, flowCell, boundaryBoxCell],
+      },
+    ],
+    diagramTop: 1,
+    threatTop: 0,
+    reviewer: '',
+  },
+};
+
+describe('v2Adapter', () => {
+  describe('getDiagramCells', () => {
+    it('returns cells for an existing diagram', () => {
+      expect(v2Adapter.getDiagramCells(model, 0)).toHaveLength(3);
+    });
+
+    it('returns undefined for a missing diagram', () => {
+      expect(v2Adapter.getDiagramCells(model, 99)).toBeUndefined();
+    });
+  });
+
+  describe('findCell', () => {
+    it('finds a cell by id', () => {
+      expect(v2Adapter.findCell(model, 0, 'actor-1')?.id).toBe('actor-1');
+    });
+
+    it('returns undefined for a missing cell', () => {
+      expect(v2Adapter.findCell(model, 0, 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('getCellThreats', () => {
+    it('reads threats from data.threats', () => {
+      const cell: CellV2 = {
+        ...actorCell,
+        data: {
+          type: 'tm.Actor',
+          name: 'X',
+          hasOpenThreats: true,
+          threats: [
+            {
+              title: 't',
+              status: 'Open',
+              severity: 'High',
+              description: '',
+              mitigation: '',
+              type: 'x',
+            },
+          ],
+        },
+      };
+      expect(v2Adapter.getCellThreats(cell)).toHaveLength(1);
+    });
+
+    it('falls back to cell.threats if data.threats is absent', () => {
+      const cell = {
+        id: 'x',
+        shape: 'actor',
+        zIndex: 0,
+        threats: [
+          {
+            title: 't',
+            status: 'Open',
+            severity: 'High',
+            description: '',
+            mitigation: '',
+            type: 'x',
+          },
+        ],
+        data: { type: 'tm.Actor', name: 'X', hasOpenThreats: false },
+      } as unknown as CellV2;
+      expect(v2Adapter.getCellThreats(cell)).toHaveLength(1);
+    });
+
+    it('returns empty array when no threats anywhere', () => {
+      expect(v2Adapter.getCellThreats(actorCell)).toEqual([]);
+    });
+  });
+
+  describe('setCellThreats', () => {
+    it('writes threats to data.threats and recomputes hasOpenThreats', () => {
+      const cell: CellV2 = {
+        ...actorCell,
+        data: { type: 'tm.Actor', name: 'X', hasOpenThreats: false },
+      };
+      const t: ThreatDragonThreat = {
+        title: 't',
+        status: 'Open',
+        severity: 'High',
+        description: '',
+        mitigation: '',
+        type: 'x',
+      };
+      v2Adapter.setCellThreats(cell, [t]);
+      expect(cell.data.threats).toHaveLength(1);
+      expect(cell.data.hasOpenThreats).toBe(true);
+    });
+
+    it('preserves hasOpenThreats=true when adding Mitigated threat to already-open cell', () => {
+      const cell: CellV2 = {
+        ...actorCell,
+        data: { type: 'tm.Actor', name: 'X', hasOpenThreats: true },
+      };
+      const t: ThreatDragonThreat = {
+        title: 't',
+        status: 'Mitigated',
+        severity: 'High',
+        description: '',
+        mitigation: '',
+        type: 'x',
+      };
+      v2Adapter.setCellThreats(cell, [t]);
+      expect(cell.data.hasOpenThreats).toBe(true);
+    });
+
+    it('initializes data if absent', () => {
+      const cell = {
+        id: 'x',
+        shape: 'actor',
+        zIndex: 0,
+      } as unknown as CellV2;
+      v2Adapter.setCellThreats(cell, []);
+      expect(cell.data).toBeDefined();
+      expect(cell.data.threats).toEqual([]);
+    });
+  });
+
+  describe('getComponentName', () => {
+    it('returns empty for undefined', () => {
+      expect(v2Adapter.getComponentName(undefined)).toBe('');
+    });
+
+    it('returns name for actor from data.name', () => {
+      expect(v2Adapter.getComponentName(actorCell)).toBe('Actor: Browser');
+    });
+
+    it('returns name for flow from labelText', () => {
+      expect(v2Adapter.getComponentName(flowCell)).toBe('Flow: Web Request');
+    });
+
+    it('falls back to data.name for flow if no label', () => {
+      const cell: CellV2 = {
+        ...flowCell,
+        labels: [],
+      };
+      expect(v2Adapter.getComponentName(cell)).toBe('Flow: Web Request');
+    });
+  });
+
+  describe('toJointGraph', () => {
+    it('adapts V2 cells to JointJS shape', () => {
+      const graph = v2Adapter.toJointGraph(model, 0);
+      expect(graph.cells).toHaveLength(3);
+
+      const actor = graph.cells[0] as Record<string, unknown>;
+      expect(actor.type).toBe('tm.Actor');
+      expect(actor.z).toBe(1);
+      expect(actor.position).toEqual({ x: 10, y: 20 });
+      expect(actor.size).toEqual({ width: 100, height: 80 });
+      expect((actor.attrs as { text: { text: string } }).text.text).toBe(
+        'Browser',
+      );
+      expect(actor.threats).toEqual([]);
+    });
+
+    it('maps flow edges with source.id / target.id / smooth', () => {
+      const graph = v2Adapter.toJointGraph(model, 0);
+      const flow = graph.cells[1] as Record<string, unknown>;
+      expect(flow.type).toBe('tm.Flow');
+      expect((flow.source as { id: string }).id).toBe('actor-1');
+      expect((flow.target as { id: string }).id).toBe('process-1');
+      expect(flow.smooth).toBe(true);
+      expect(flow.vertices).toEqual([{ x: 100, y: 50 }]);
+    });
+
+    it('maps tm.BoundaryBox to tm.Boundary', () => {
+      const graph = v2Adapter.toJointGraph(model, 0);
+      const boundary = graph.cells[2] as Record<string, unknown>;
+      expect(boundary.type).toBe('tm.Boundary');
+    });
+
+    it('maps data.threats to top-level threats on JointJS cell', () => {
+      const cellWithThreats: CellV2 = {
+        ...actorCell,
+        data: {
+          type: 'tm.Actor',
+          name: 'X',
+          hasOpenThreats: true,
+          threats: [
+            {
+              title: 't',
+              status: 'Open',
+              severity: 'High',
+              description: '',
+              mitigation: '',
+              type: 'x',
+            },
+          ],
+        },
+      };
+      const m: ThreatDragonModelV2 = {
+        ...model,
+        detail: {
+          ...model.detail,
+          diagrams: [
+            {
+              ...model.detail.diagrams[0]!,
+              cells: [cellWithThreats],
+            },
+          ],
+        },
+      };
+      const graph = v2Adapter.toJointGraph(m, 0);
+      const cell = graph.cells[0] as Record<string, unknown>;
+      expect(cell.threats).toHaveLength(1);
+    });
+
+    it('returns empty cells for missing diagram', () => {
+      expect(v2Adapter.toJointGraph(model, 99).cells).toEqual([]);
+    });
+  });
+
+  describe('validate', () => {
+    it('accepts a valid V2 model', () => {
+      expect(v2Adapter.validate(model).valid).toBe(true);
+    });
+
+    it('rejects non-object', () => {
+      expect(v2Adapter.validate(null).valid).toBe(false);
+    });
+
+    it('rejects missing version', () => {
+      const m = { ...model } as Record<string, unknown>;
+      delete m.version;
+      expect(v2Adapter.validate(m).valid).toBe(false);
+    });
+
+    it('rejects missing diagramTop', () => {
+      const m = { ...model, detail: { ...model.detail } } as Record<
+        string,
+        unknown
+      >;
+      delete (m.detail as Record<string, unknown>).diagramTop;
+      expect(v2Adapter.validate(m).valid).toBe(false);
+    });
+
+    it('rejects diagram without cells array', () => {
+      expect(
+        v2Adapter.validate({
+          version: '2.0.0',
+          summary: { title: 'x' },
+          detail: {
+            contributors: [],
+            diagrams: [
+              { id: 0, title: '', diagramType: '', thumbnail: '', version: '' },
+            ],
+            diagramTop: 1,
+            threatTop: 0,
+            reviewer: '',
+          },
+        }).valid,
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/game/ThreatDragonModel.v2.ts
+++ b/packages/shared/src/game/ThreatDragonModel.v2.ts
@@ -1,0 +1,580 @@
+/**
+ * Threat Dragon V2 threat model types and adapter.
+ *
+ * This module is intentionally self-contained so that V1 and V2 are clearly
+ * separated. The V2 adapter handles the differences between the V2 schema
+ * (cells with shape/zIndex/data, threats in data.threats) and the V1-based
+ * JointJS rendering pipeline used by this project.
+ *
+ * References:
+ * - OWASP Threat Dragon schema V2:
+ *   https://owasp.org/www-project-threat-dragon/assets/schemas/owasp.threat-dragon.schema.V2.json
+ * - Threat Dragon V2 data structure (cells/data/threats):
+ *   https://deepwiki.com/OWASP/threat-dragon/2.1-threat-model-data-structure
+ */
+import type {
+  ThreatDragonThreat,
+  ThreatModelAdapter,
+} from './ThreatDragonModel';
+
+export interface ThreatDragonModelV2 {
+  version: string;
+  summary: ThreatDragonSummaryV2;
+  detail: ThreatDragonDetailV2;
+  [k: string]: unknown;
+}
+
+export interface ThreatDragonSummaryV2 {
+  title: string;
+  owner?: string;
+  description?: string;
+  id?: number | string;
+  [k: string]: unknown;
+}
+
+export interface ThreatDragonDetailV2 {
+  contributors: ContributorV2[];
+  diagrams: DiagramV2[];
+  diagramTop: number;
+  threatTop: number;
+  reviewer: string;
+  [k: string]: unknown;
+}
+
+export interface ContributorV2 {
+  name: string;
+  [k: string]: unknown;
+}
+
+export interface DiagramV2 {
+  id: number;
+  title: string;
+  diagramType: string;
+  description?: string;
+  placeholder?: string;
+  thumbnail: string;
+  version: string;
+  cells: CellV2[];
+  [k: string]: unknown;
+}
+
+export interface PointV2 {
+  x: number;
+  y: number;
+  [k: string]: unknown;
+}
+
+export interface CellV2 {
+  id: string;
+  shape: string;
+  zIndex: number;
+  attrs?: Record<string, unknown>;
+  data: CellDataV2;
+  visible?: boolean;
+  position?: PointV2;
+  size?: { width: number; height: number; [k: string]: unknown };
+  source?: EdgeEndV2;
+  target?: EdgeEndV2;
+  vertices?: PointV2[];
+  connector?: string;
+  labels?: EdgeLabelV2[];
+  ports?: PortsV2;
+  width?: number;
+  height?: number;
+  angle?: number;
+  [k: string]: unknown;
+}
+
+export interface EdgeEndV2 {
+  cell?: string;
+  port?: string;
+  x?: number;
+  y?: number;
+  [k: string]: unknown;
+}
+
+export interface EdgeLabelV2 {
+  attrs?: Record<string, unknown>;
+  markup?: Array<{ tagName: string; selector: string; [k: string]: unknown }>;
+  position?: {
+    distance?: number;
+    args?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+export interface PortsV2 {
+  groups?: Record<
+    string,
+    {
+      position?: string;
+      attrs?: Record<string, unknown>;
+      [k: string]: unknown;
+    }
+  >;
+  items?: Array<{
+    group: string;
+    id: string;
+    [k: string]: unknown;
+  }>;
+  [k: string]: unknown;
+}
+
+export interface BaseCellDataV2 {
+  type: string;
+  name: string;
+  description?: string;
+  outOfScope?: boolean;
+  reasonOutOfScope?: string;
+  hasOpenThreats: boolean;
+  isTrustBoundary?: boolean;
+  threats?: ThreatDragonThreat[];
+  [k: string]: unknown;
+}
+
+export type CellDataV2 =
+  | ProcessDataV2
+  | StoreDataV2
+  | ActorDataV2
+  | FlowDataV2
+  | BoundaryDataV2
+  | BoundaryBoxDataV2
+  | TextBlockDataV2
+  | (BaseCellDataV2 & { type: string });
+
+export interface ProcessDataV2 extends BaseCellDataV2 {
+  type: 'tm.Process';
+  handlesCardPayment?: boolean;
+  handlesGoodsOrServices?: boolean;
+  isWebApplication?: boolean;
+  privilegeLevel?: string;
+  [k: string]: unknown;
+}
+
+export interface StoreDataV2 extends BaseCellDataV2 {
+  type: 'tm.Store';
+  isALog?: boolean;
+  isEncrypted?: boolean;
+  isSigned?: boolean;
+  storesCredentials?: boolean;
+  storesInventory?: boolean;
+  [k: string]: unknown;
+}
+
+export interface ActorDataV2 extends BaseCellDataV2 {
+  type: 'tm.Actor';
+  providesAuthentication?: boolean;
+  [k: string]: unknown;
+}
+
+export interface FlowDataV2 extends BaseCellDataV2 {
+  type: 'tm.Flow';
+  isBidirectional?: boolean;
+  isEncrypted?: boolean;
+  isPublicNetwork?: boolean;
+  protocol?: string;
+  [k: string]: unknown;
+}
+
+export interface BoundaryDataV2 extends BaseCellDataV2 {
+  type: 'tm.Boundary';
+  isTrustBoundary: boolean;
+  [k: string]: unknown;
+}
+
+export interface BoundaryBoxDataV2 extends BaseCellDataV2 {
+  type: 'tm.BoundaryBox';
+  isTrustBoundary: boolean;
+  [k: string]: unknown;
+}
+
+export interface TextBlockDataV2 extends BaseCellDataV2 {
+  type: 'tm.Text';
+  [k: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// JointJS adaptation types (internal)
+// ---------------------------------------------------------------------------
+
+type JointAttrs = Record<string, unknown>;
+
+type JointEdgeEnd =
+  | { id: string; port?: string }
+  | { x: number; y: number }
+  | Record<string, never>;
+
+interface JointLabel {
+  position: number;
+  attrs: {
+    text: { text: string };
+  };
+}
+
+interface JointCellBase {
+  id: string;
+  type: string;
+  z: number;
+  attrs: JointAttrs;
+  description?: string;
+  hasOpenThreats?: boolean;
+  outOfScope?: boolean;
+  reasonOutOfScope?: string;
+  isTrustBoundary?: boolean;
+  threats?: unknown[];
+  visible?: boolean;
+  angle?: number;
+}
+
+interface JointNodeCell extends JointCellBase {
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+}
+
+interface JointEdgeCell extends JointCellBase {
+  source: JointEdgeEnd;
+  target: JointEdgeEnd;
+  vertices: Array<{ x: number; y: number }>;
+  smooth?: boolean;
+  labels?: JointLabel[];
+  isBidirectional?: boolean;
+  isEncrypted?: boolean;
+  isPublicNetwork?: boolean;
+  protocol?: string;
+}
+
+type JointCell = JointNodeCell | JointEdgeCell;
+
+// ---------------------------------------------------------------------------
+// V2 Adapter
+// ---------------------------------------------------------------------------
+
+export const v2Adapter: ThreatModelAdapter<ThreatDragonModelV2, CellV2> = {
+  getDiagramCells(model, diagramIdx) {
+    return model.detail.diagrams[diagramIdx]?.cells;
+  },
+
+  findCell(model, diagramIdx, cellId) {
+    return model.detail.diagrams[diagramIdx]?.cells?.find(
+      (c) => c.id === cellId,
+    );
+  },
+
+  getCellThreats(cell) {
+    const fromData = cell.data?.threats;
+    if (fromData) return fromData;
+    const fromCell = (cell as { threats?: ThreatDragonThreat[] }).threats;
+    return fromCell ?? [];
+  },
+
+  setCellThreats(cell, threats) {
+    if (!cell.data) {
+      cell.data = { type: '', name: '', hasOpenThreats: false } as CellDataV2;
+    }
+    cell.data.threats = threats;
+    cell.data.hasOpenThreats =
+      cell.data.hasOpenThreats || threats.some((t) => t.status === 'Open');
+  },
+
+  getComponentName(component) {
+    if (!component) return '';
+
+    const type = getV2CellType(component);
+    const prefix = type.startsWith('tm.') ? type.slice(3) : type;
+
+    if (type === 'tm.Flow') {
+      const flowLabel = getV2FlowLabel(component);
+      const fallbackName = getV2CellDisplayName(component);
+      const name = flowLabel || fallbackName;
+      return name ? `${prefix}: ${name}` : `${prefix}`;
+    }
+
+    const name = getV2CellDisplayName(component);
+    return name ? `${prefix}: ${name}` : `${prefix}`;
+  },
+
+  toJointGraph(model, diagramIdx) {
+    const diagram = model.detail.diagrams[diagramIdx];
+    if (!diagram) return { cells: [] };
+    return toJointGraphJson(diagram);
+  },
+
+  validate(model) {
+    const errors: string[] = [];
+
+    if (typeof model !== 'object' || model === null || Array.isArray(model)) {
+      return { valid: false, errors: ['Model must be an object'] };
+    }
+
+    const m = model as Record<string, unknown>;
+
+    if (typeof m.version !== 'string') {
+      errors.push('version must be a string');
+    }
+
+    const summary = m.summary as Record<string, unknown> | undefined;
+    if (!summary || typeof summary.title !== 'string') {
+      errors.push('summary.title must be a string');
+    }
+
+    const detail = m.detail as Record<string, unknown> | undefined;
+    if (!detail || !Array.isArray(detail.diagrams)) {
+      errors.push('detail.diagrams must be an array');
+      return { valid: errors.length === 0, errors };
+    }
+
+    if (typeof detail.diagramTop !== 'number') {
+      errors.push('detail.diagramTop must be a number');
+    }
+
+    if (typeof detail.threatTop !== 'number') {
+      errors.push('detail.threatTop must be a number');
+    }
+
+    for (const [i, d] of (detail.diagrams as unknown[]).entries()) {
+      const diag = d as Record<string, unknown>;
+      if (!diag || typeof diag !== 'object' || !Array.isArray(diag.cells)) {
+        errors.push(`diagram[${i}].cells must be an array`);
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// V2 → JointJS graph adaptation (private helpers)
+// ---------------------------------------------------------------------------
+
+function toJointGraphJson(diagram: DiagramV2): { cells: JointCell[] } {
+  const cells = (diagram.cells ?? [])
+    .map(v2CellToJointCell)
+    .filter((c): c is JointCell => c !== null);
+  return { cells };
+}
+
+function v2CellToJointCell(cell: CellV2): JointCell | null {
+  const dataType = cell.data?.type;
+  const shape = cell.shape;
+
+  const base: JointCellBase = {
+    id: cell.id,
+    type: mapToJointType(shape, dataType),
+    z: cell.zIndex ? cell.zIndex : 0,
+    attrs: normalizeAttrs(cell),
+  };
+
+  if (cell.angle !== undefined) {
+    base.angle = cell.angle;
+  }
+
+  // Node cells: position + size
+  if (cell.position && cell.size) {
+    const node: JointNodeCell = {
+      ...base,
+      position: { x: cell.position.x, y: cell.position.y },
+      size: { width: cell.size.width, height: cell.size.height },
+      description: cell.data?.description ?? '',
+      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      outOfScope: !!cell.data?.outOfScope,
+      reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
+      isTrustBoundary: !!cell.data?.isTrustBoundary,
+      threats: cell.data?.threats ?? [],
+      visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
+    };
+    return node;
+  }
+
+  // Edge cells: source/target/vertices (flows, boundary curves)
+  if (cell.source || cell.target) {
+    const edge: JointEdgeCell = {
+      ...base,
+      source: mapEdgeEnd(cell.source),
+      target: mapEdgeEnd(cell.target),
+      vertices: Array.isArray(cell.vertices)
+        ? cell.vertices.map((v) => ({ x: v.x, y: v.y }))
+        : [],
+      smooth:
+        typeof cell.connector === 'string'
+          ? cell.connector === 'smooth'
+          : undefined,
+      description: cell.data?.description ?? '',
+      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      outOfScope: !!cell.data?.outOfScope,
+      reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
+      isTrustBoundary: !!cell.data?.isTrustBoundary,
+      threats: cell.data?.threats ?? [],
+      visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
+    };
+
+    const labels = mapEdgeLabels(cell);
+    if (labels.length) edge.labels = labels;
+
+    if (cell.data?.type === 'tm.Flow') {
+      const d = cell.data;
+      edge.isBidirectional = !!d.isBidirectional;
+      edge.isEncrypted = !!d.isEncrypted;
+      edge.isPublicNetwork = !!d.isPublicNetwork;
+      edge.protocol = typeof d.protocol === 'string' ? d.protocol : '';
+    }
+
+    return edge;
+  }
+
+  // Fallback: if neither node nor edge fields exist, render as node with
+  // best-effort geometry so the cell is at least visible.
+  if (cell.data) {
+    const node: JointNodeCell = {
+      ...base,
+      position: cell.position
+        ? { x: cell.position.x, y: cell.position.y }
+        : { x: 0, y: 0 },
+      size: cell.size
+        ? { width: cell.size.width, height: cell.size.height }
+        : { width: 100, height: 100 },
+      description: cell.data?.description ?? '',
+      hasOpenThreats: !!cell.data?.hasOpenThreats,
+      outOfScope: !!cell.data?.outOfScope,
+      reasonOutOfScope: cell.data?.reasonOutOfScope ?? '',
+      isTrustBoundary: !!cell.data?.isTrustBoundary,
+      threats: cell.data?.threats ?? [],
+      visible: typeof cell.visible === 'boolean' ? cell.visible : undefined,
+    };
+    return node;
+  }
+
+  return null;
+}
+
+function mapToJointType(shape: string, dataType?: string): string {
+  if (typeof dataType === 'string' && dataType.startsWith('tm.')) {
+    if (dataType === 'tm.BoundaryBox') return 'tm.Boundary';
+    if (dataType === 'tm.Text') return 'tm.Process';
+    return dataType;
+  }
+
+  switch (shape) {
+    case 'process':
+      return 'tm.Process';
+    case 'actor':
+      return 'tm.Actor';
+    case 'store':
+      return 'tm.Store';
+    case 'flow':
+      return 'tm.Flow';
+    case 'trust-boundary-curve':
+    case 'trust-boundary-box':
+      return 'tm.Boundary';
+    default:
+      return 'tm.Process';
+  }
+}
+
+function mapEdgeEnd(end: CellV2['source']): JointEdgeEnd {
+  if (!end) return {};
+
+  if (typeof end.x === 'number' && typeof end.y === 'number') {
+    return { x: end.x, y: end.y };
+  }
+
+  if (typeof end.cell === 'string') {
+    return {
+      id: end.cell,
+      port: typeof end.port === 'string' ? end.port : undefined,
+    };
+  }
+
+  return {};
+}
+
+function normalizeAttrs(cell: CellV2): JointAttrs {
+  const attrs: JointAttrs = { ...(cell.attrs ?? {}) };
+  const name = getV2CellName(cell);
+  if (name) {
+    const textObj = (attrs as { text?: Record<string, unknown> }).text ?? {};
+    (attrs as { text?: Record<string, unknown> }).text = textObj;
+    if (typeof (textObj as { text?: unknown }).text !== 'string') {
+      (textObj as { text?: unknown }).text = name;
+    }
+  }
+  return attrs;
+}
+
+function getV2CellName(cell: CellV2): string {
+  if (typeof cell.data?.name === 'string' && cell.data.name.trim()) {
+    return cell.data.name;
+  }
+  const a = cell.attrs;
+  if (a && typeof a === 'object') {
+    const t1 = (a as { text?: { text?: unknown } }).text?.text;
+    if (typeof t1 === 'string' && t1.trim()) return t1;
+    const t2 = (a as { label?: { text?: unknown } }).label?.text;
+    if (typeof t2 === 'string' && t2.trim()) return t2;
+  }
+  return '';
+}
+
+function mapEdgeLabels(cell: CellV2): JointLabel[] {
+  const labels = cell.labels ?? [];
+  const out: JointLabel[] = [];
+  for (const l of labels) {
+    const attrs = l.attrs;
+    if (!attrs || typeof attrs !== 'object') continue;
+
+    const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
+      ?.text;
+    const fallback = (attrs as { label?: { text?: unknown } }).label?.text;
+
+    const text =
+      typeof labelText === 'string' && labelText.trim()
+        ? labelText
+        : typeof fallback === 'string'
+          ? fallback
+          : '';
+
+    if (!text || !text.trim()) continue;
+
+    out.push({
+      position:
+        typeof l.position?.distance === 'number' ? l.position.distance : 0.5,
+      attrs: { text: { text } },
+    });
+  }
+  return out;
+}
+
+function getV2CellType(cell: CellV2): string {
+  return typeof cell.data?.type === 'string' ? cell.data.type : '';
+}
+
+function getV2CellDisplayName(cell: CellV2): string {
+  const dataName = cell.data?.name;
+  if (typeof dataName === 'string' && dataName.trim()) return dataName;
+
+  const attrs = cell.attrs;
+  if (attrs && typeof attrs === 'object') {
+    const t1 = (attrs as { text?: { text?: unknown } }).text?.text;
+    if (typeof t1 === 'string' && t1.trim()) return t1;
+    const t2 = (attrs as { label?: { text?: unknown } }).label?.text;
+    if (typeof t2 === 'string' && t2.trim()) return t2;
+  }
+  return '';
+}
+
+function getV2FlowLabel(cell: CellV2): string {
+  const labels = cell.labels ?? [];
+  if (!Array.isArray(labels) || labels.length === 0) return '';
+
+  const attrs = labels[0]?.attrs;
+  if (!attrs || typeof attrs !== 'object') return '';
+
+  const labelText = (attrs as { labelText?: { text?: unknown } }).labelText
+    ?.text;
+  if (typeof labelText === 'string' && labelText.trim()) return labelText;
+
+  const label = (attrs as { label?: { text?: unknown } }).label?.text;
+  if (typeof label === 'string' && label.trim()) return label;
+
+  return '';
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './game/eop';
 export * from './game/gameState';
 export * from './game/setupData';
+export * from './game/threat';
 export * from './game/ThreatDragonModel';
 
 export * from './utils/constants';

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { ThreatDragonModel } from '../game/ThreatDragonModel';
+import type { ThreatDragonModelV2 } from '../game/ThreatDragonModel';
 
 export enum ModelType {
   THREAT_DRAGON = 'Threat Dragon',
@@ -13,7 +13,8 @@ export const MIN_NUMBER_PLAYERS = 2;
 export const MAX_NUMBER_PLAYERS = 9;
 export const DEFAULT_TURN_DURATION = 300;
 
-export const DEFAULT_MODEL: ThreatDragonModel = {
+export const DEFAULT_MODEL: ThreatDragonModelV2 = {
+  version: '2.0.0',
   summary: {
     title: 'Threat Modelling',
   },
@@ -21,46 +22,44 @@ export const DEFAULT_MODEL: ThreatDragonModel = {
     contributors: [],
     diagrams: [
       {
+        id: 0,
         title: 'Threat Modelling',
         thumbnail: '',
         diagramType: 'STRIDE',
-        id: 0,
-        diagramJson: {
-          cells: [
-            {
-              type: 'tm.Actor',
-              size: {
-                width: 160,
-                height: 80,
-              },
-              position: {
-                x: 50,
-                y: 50,
-              },
-              angle: 0,
-              id: '90cdcc2d-21ab-443d-ae95-f97a798429e7',
-              z: 1,
-              hasOpenThreats: false,
-              attrs: {
-                '.element-shape': {
-                  class: 'element-shape hasNoOpenThreats isInScope',
-                },
-                text: {
-                  text: 'Application',
-                },
-                '.element-text': {
-                  class: 'element-text hasNoOpenThreats isInScope',
-                },
+        version: '2.0.0',
+        cells: [
+          {
+            id: '90cdcc2d-21ab-443d-ae95-f97a798429e7',
+            shape: 'actor',
+            zIndex: 1,
+            visible: true,
+            position: { x: 50, y: 50 },
+            size: { width: 160, height: 80 },
+            attrs: {
+              text: { text: 'Application' },
+              body: {
+                stroke: '#333333',
+                strokeWidth: 1.5,
+                strokeDasharray: null,
               },
             },
-          ],
-        },
-        size: {
-          height: 590,
-          width: 790,
-        },
+            data: {
+              type: 'tm.Actor',
+              name: 'Application',
+              description: '',
+              outOfScope: false,
+              reasonOutOfScope: '',
+              hasOpenThreats: false,
+              providesAuthentication: false,
+              threats: [],
+            },
+          },
+        ],
       },
     ],
+    diagramTop: 1,
+    threatTop: 0,
+    reviewer: '',
   },
 };
 

--- a/packages/shared/src/utils/utils.test.ts
+++ b/packages/shared/src/utils/utils.test.ts
@@ -5,7 +5,6 @@ import { getStartingCard } from './cardDefinitions';
 import { DEFAULT_START_SUIT, ModelType } from './constants';
 import {
   escapeMarkdownText,
-  getComponentName,
   getDealtCard,
   getPlayers,
   getValidMoves,
@@ -101,41 +100,8 @@ it('creates player array correctly', () => {
 });
 
 it('makes correct component name', () => {
-  expect(getComponentName(undefined)).toBe('');
-  expect(
-    getComponentName({
-      type: 'tm.Actor',
-      attrs: {
-        text: {
-          text: 'Bar',
-        },
-      },
-      id: 'some-id',
-      size: { width: 0, height: 0 },
-      z: 0,
-    }),
-  ).toBe('Actor: Bar');
-  expect(
-    getComponentName({
-      type: 'tm.Flow',
-      labels: [
-        {
-          attrs: {
-            text: {
-              text: 'Bar',
-              'font-size': '12pt',
-              'font-weight': 'bold',
-            },
-          },
-          position: 0,
-        },
-      ],
-      attrs: {},
-      id: 'some-id',
-      size: { width: 0, height: 0 },
-      z: 0,
-    }),
-  ).toBe('Flow: Bar');
+  // getComponentName has moved to the V1/V2 adapters; see
+  // ThreatDragonModel.v1.test.ts and ThreatDragonModel.v2.test.ts.
 });
 
 it('produces valid moves', () => {

--- a/packages/shared/src/utils/utils.ts
+++ b/packages/shared/src/utils/utils.ts
@@ -1,6 +1,5 @@
 import type { PlayerID } from 'boardgame.io';
 import type { GameState } from '../game/gameState';
-import type { ThreatDragonComponent } from '../game/ThreatDragonModel';
 import type { Card, Suit } from './cardDefinitions';
 import { ModelType } from './constants';
 
@@ -41,20 +40,6 @@ export function getPlayers(count: number): string[] {
     players.push(i + '');
   }
   return players;
-}
-
-export function getComponentName(
-  component: ThreatDragonComponent | undefined,
-): string {
-  if (component === undefined) return '';
-
-  const prefix = component.type.slice(3);
-
-  if (component.type === 'tm.Flow') {
-    return `${prefix}: ${component.labels?.[0]?.attrs.text.text}`;
-  }
-
-  return `${prefix}: ${component.attrs.text?.text}`;
 }
 
 export function getValidMoves(


### PR DESCRIPTION
Add support for Threat Dragon schema version 2 model files. Users can
    upload v2 JSON models which are used in the game as-is (no conversion
    to v1). Adding threats updates the v2 model and downloading returns
    the updated v2 model. V1 continues to work exactly as before.
    
    The implementation uses an adapter pattern where V1 and V2 live in
    fully separate modules (ThreatDragonModel.v1.ts, ThreatDragonModel.v2.ts)
    behind a common ThreatModelAdapter interface. A single getModelAdapter()
    dispatcher is the only place that knows about both versions. All call
    sites (endpoints, model rendering, threatbar) go through the dispatcher
    and contain no version branching. Dropping V1 in the future requires
    deleting the v1 module and simplifying the dispatcher - zero call-site
    changes.
    
    Key V2 differences handled:
    - cells moved from diagram.diagramJson.cells to diagram.cells
    - cell type moved from cell.type to cell.data.type (same tm.* values)
    - component name moved from cell.attrs.text.text to cell.data.name
    - threats stored in cell.data.threats (with dual-read fallback to
      cell.threats for schema-literal files)
    - zIndex instead of z, source.cell instead of source.id
    - V2 edge labels use labelText.text instead of text.text
    - tm.BoundaryBox mapped to tm.Boundary, tm.Text mapped to tm.Process
    - hasOpenThreats recomputed after writing threats
    
    Also adds light upload validation via validateThreatDragonModel(),
    a V2 sample model link on the create page, and migrates the internal
    DEFAULT_MODEL to V2.